### PR TITLE
Added a basic compose.yml for developing in docker

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,14 @@
+name: traffic-analytics-proxy
+
+services:
+  traffic-analytics-proxy:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 3000:3000
+    volumes:
+      - .:/usr/src/app
+      - /usr/src/app/node_modules
+    env_file:
+      - .env


### PR DESCRIPTION
no issue

- Adds a `compose.yml` so we can easily run the proxy locally with docker. This should make it easier to ensure we're all running in the same environment, and to make our local environments more similar to the production environment.