### PR TITLE
Added eslint rules for newlines and trailing spaces

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,5 +2,9 @@ module.exports = {
     plugins: ['ghost'],
     extends: [
         'plugin:ghost/node'
-    ]
+    ],
+    rules: {
+        'eol-last': ['error', 'always'],
+        'no-trailing-spaces': 'error'
+    }
 };

--- a/src/app.js
+++ b/src/app.js
@@ -53,7 +53,7 @@ fastify.register(require('@fastify/http-proxy'), {
         const searchParams = new URLSearchParams(request.url.split('?')[1] || '');
         const token = searchParams.get('token');
         const name = searchParams.get('name');
-        
+
         // Verify both token and name are present and not empty
         if (!token || token.trim() === '' || !name || name.trim() === '') {
             reply.code(400).send({
@@ -62,7 +62,7 @@ fastify.register(require('@fastify/http-proxy'), {
             });
             return;
         }
-        
+
         done();
     },
     rewriteRequest: (req) => {

--- a/src/utils/query-params.js
+++ b/src/utils/query-params.js
@@ -6,11 +6,11 @@
 function filterQueryParams(url) {
     // Get query parameters without creating a full URL object
     const searchParams = new URLSearchParams(url.split('?')[1] || '');
-    
+
     // Extract only token and name
     const token = searchParams.get('token');
     const name = searchParams.get('name');
-    
+
     // Create new query string with only these parameters
     const newSearchParams = new URLSearchParams();
     if (token && token.trim() !== '') {
@@ -19,7 +19,7 @@ function filterQueryParams(url) {
     if (name && name.trim() !== '') {
         newSearchParams.set('name', name);
     }
-    
+
     // Update the request URL (keep pathname, replace query)
     const path = url.split('?')[0];
     return path + (newSearchParams.toString() ? `?${newSearchParams.toString()}` : '');
@@ -27,4 +27,4 @@ function filterQueryParams(url) {
 
 module.exports = {
     filterQueryParams
-}; 
+};


### PR DESCRIPTION
no issue

- My commits seem to always have unrelated changes for adding a newline at the end of each file, and for deleting any trailing whitespace on empty lines. Our editors must be configured differently.
- This commit adds rules for these changes to eslint, so it should enforce it the same way for all of us, and not depend on each contributor's editor's configuration.
- These rules should automatically be fixed with `yarn lint --fix`, or if your editor lints on save.