### PR TITLE
Refactored core validation and processing logic into a service

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@fastify/cors": "11.0.1",
     "@fastify/http-proxy": "11.1.2",
+    "@tryghost/errors": "^1.3.7",
     "dotenv": "16.5.0",
     "fastify": "5.3.0",
     "pino-pretty": "10.3.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-ghost": "3.4.0",
     "mocha": "11.1.0",
     "nodemon": "3.1.9",
-    "sinon": "20.0.0",
+    "sinon": "^20.0.0",
     "supertest": "6.3.4"
   },
   "dependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,7 @@
 // Main module file
 require('dotenv').config();
 const {filterQueryParams} = require('./utils/query-params');
-const uap = require('ua-parser-js');
+const {processRequest} = require('./lib/proxy');
 
 const fastify = require('fastify')({
     logger: {
@@ -77,20 +77,7 @@ fastify.register(require('@fastify/http-proxy'), {
         done();
     },
     preHandler: (request, reply, done) => {
-        // Process & Modify the request body
-        try {
-            const ua = new uap(request.headers['user-agent']);
-            const os = ua.getOS() || {name: 'unknown', version: 'unknown'};
-            const browser = ua.getBrowser() || {name: 'unknown', version: 'unknown', major: 'unknown', type: 'unknown'};
-            const device = ua.getDevice() || {type: 'unknown', vendor: 'unknown', model: 'unknown'};
-            request.body.payload.meta = {};
-            request.body.payload.meta.os = os;
-            request.body.payload.meta.browser = browser;
-            request.body.payload.meta.device = device;
-        } catch (error) {
-            request.log.error(error);
-            // We should fail silently here, because we don't want to break the proxy for non-critical functionality
-        }
+        processRequest(request);
 
         done();
     },

--- a/src/services/proxy/index.js
+++ b/src/services/proxy/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./proxy');

--- a/src/services/proxy/processors.js
+++ b/src/services/proxy/processors.js
@@ -1,0 +1,25 @@
+const uap = require('ua-parser-js');
+
+function parseUserAgent(request) {
+    if (!request.headers['user-agent']) {
+        return;
+    }
+
+    try {
+        const ua = new uap(request.headers['user-agent']);
+        const os = ua.getOS() || {name: 'unknown', version: 'unknown'};
+        const browser = ua.getBrowser() || {name: 'unknown', version: 'unknown', major: 'unknown', type: 'unknown'};
+        const device = ua.getDevice() || {type: 'unknown', vendor: 'unknown', model: 'unknown'};
+        request.body.payload.meta = {};
+        request.body.payload.meta.os = os;
+        request.body.payload.meta.browser = browser;
+        request.body.payload.meta.device = device;
+    } catch (error) {
+        request.log.error(error);
+        // We should fail silently here, because we don't want to break the proxy for non-critical functionality
+    }
+}
+
+module.exports = {
+    parseUserAgent
+};

--- a/src/services/proxy/proxy.js
+++ b/src/services/proxy/proxy.js
@@ -1,4 +1,5 @@
-const uap = require('ua-parser-js');
+const validators = require('./validators');
+const processors = require('./processors');
 
 // Accepts a request object
 // Does some processing — user agent parsing, geoip lookup, etc.
@@ -6,54 +7,27 @@ const uap = require('ua-parser-js');
 // Called within the HTTP proxy route
 // Eventually will be called on each request pulled from the queue
 function processRequest(request, reply, done) {
-    parseUserAgent(request);
+    try {
+        processors.parseUserAgent(request);
+    } catch (error) {
+        reply.code(500).send(error);
+        return;
+    }
     done();
 }
 
 function validateRequest(request, reply, done) {
-    // Validate the request before proxying it
-    const token = request.query.token;
-    const name = request.query.name;
-
-    // Verify both token and name are present and not empty
-    if (!token || token.trim() === '' || !name || name.trim() === '') {
-        reply.code(400).send({
-            error: 'Bad Request',
-            message: 'Token and name query parameters are required'
-        });
-        return;
-    }
-
-    // Validate the request body
-    if (!request.body || Object.keys(request.body).length === 0 || !request.body.payload) {
-        reply.code(400).send({
-            error: 'Bad Request',
-            message: 'Request body is required'
-        });
+    try {
+        validators.validateQueryParams(request);
+        validators.validateRequestBody(request);
+    } catch (error) {
+        // TODO: This should just throw an error, not return a reply
+        // This should be decoupled from the HTTP proxy route
+        reply.code(400).send(error);
         return;
     }
 
     done();
-}
-
-function parseUserAgent(request) {
-    if (!request.headers['user-agent']) {
-        return;
-    }
-
-    try {
-        const ua = new uap(request.headers['user-agent']);
-        const os = ua.getOS() || {name: 'unknown', version: 'unknown'};
-        const browser = ua.getBrowser() || {name: 'unknown', version: 'unknown', major: 'unknown', type: 'unknown'};
-        const device = ua.getDevice() || {type: 'unknown', vendor: 'unknown', model: 'unknown'};
-        request.body.payload.meta = {};
-        request.body.payload.meta.os = os;
-        request.body.payload.meta.browser = browser;
-        request.body.payload.meta.device = device;
-    } catch (error) {
-        request.log.error(error);
-        // We should fail silently here, because we don't want to break the proxy for non-critical functionality
-    }
 }
 
 module.exports = {

--- a/src/services/proxy/proxy.js
+++ b/src/services/proxy/proxy.js
@@ -1,0 +1,62 @@
+const uap = require('ua-parser-js');
+
+// Accepts a request object
+// Does some processing — user agent parsing, geoip lookup, etc.
+// Modifies the request object in place
+// Called within the HTTP proxy route
+// Eventually will be called on each request pulled from the queue
+function processRequest(request, reply, done) {
+    parseUserAgent(request);
+    done();
+}
+
+function validateRequest(request, reply, done) {
+    // Validate the request before proxying it
+    const token = request.query.token;
+    const name = request.query.name;
+
+    // Verify both token and name are present and not empty
+    if (!token || token.trim() === '' || !name || name.trim() === '') {
+        reply.code(400).send({
+            error: 'Bad Request',
+            message: 'Token and name query parameters are required'
+        });
+        return;
+    }
+
+    // Validate the request body
+    if (!request.body || Object.keys(request.body).length === 0 || !request.body.payload) {
+        reply.code(400).send({
+            error: 'Bad Request',
+            message: 'Request body is required'
+        });
+        return;
+    }
+
+    done();
+}
+
+function parseUserAgent(request) {
+    if (!request.headers['user-agent']) {
+        return;
+    }
+
+    try {
+        const ua = new uap(request.headers['user-agent']);
+        const os = ua.getOS() || {name: 'unknown', version: 'unknown'};
+        const browser = ua.getBrowser() || {name: 'unknown', version: 'unknown', major: 'unknown', type: 'unknown'};
+        const device = ua.getDevice() || {type: 'unknown', vendor: 'unknown', model: 'unknown'};
+        request.body.payload.meta = {};
+        request.body.payload.meta.os = os;
+        request.body.payload.meta.browser = browser;
+        request.body.payload.meta.device = device;
+    } catch (error) {
+        request.log.error(error);
+        // We should fail silently here, because we don't want to break the proxy for non-critical functionality
+    }
+}
+
+module.exports = {
+    processRequest,
+    validateRequest
+};

--- a/src/services/proxy/validators.js
+++ b/src/services/proxy/validators.js
@@ -1,0 +1,31 @@
+const errors = require('@tryghost/errors');
+
+// A validator is a function that accepts a request object and throws an error if the request is invalid
+// If an error is thrown, the request is rejected
+// If no error is thrown, the request continues to the next step
+
+function validateQueryParams(request) {
+    const token = request.query.token;
+    const name = request.query.name;
+
+    if (!token || token.trim() === '' || !name || name.trim() === '') {
+        throw new errors.BadRequestError({
+            message: 'Token and name query parameters are required'
+        });
+    }
+}
+
+function validateRequestBody(request) {
+    // Validate the request body
+    if (!request.body || Object.keys(request.body).length === 0 || !request.body.payload) {
+        // TODO: This should throw an error, not return a reply
+        throw new errors.BadRequestError({
+            message: 'Request body is required'
+        });
+    }
+}
+
+module.exports = {
+    validateQueryParams,
+    validateRequestBody
+};

--- a/test/services/proxy/processors.test.js
+++ b/test/services/proxy/processors.test.js
@@ -1,0 +1,23 @@
+const {parseUserAgent} = require('../../../src/services/proxy/processors');
+const assert = require('node:assert').strict;
+describe('Processors', function () {
+    describe('parseUserAgent', function () {
+        it('should parse the user agent', function () {
+            const request = {
+                headers: {
+                    'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36'
+                },
+                body: {
+                    payload: {}
+                }
+            };
+            parseUserAgent(request);
+
+            assert.deepEqual(request.body.payload.meta, {
+                os: {name: 'Mac OS', version: '10.15.7'},
+                browser: {name: 'Chrome', version: '91.0.4472.114', major: '91'},
+                device: {type: undefined, vendor: 'Apple', model: 'Macintosh'}
+            });
+        });
+    });
+});

--- a/test/services/proxy/validators.test.js
+++ b/test/services/proxy/validators.test.js
@@ -1,0 +1,28 @@
+const {validateQueryParams, validateRequestBody} = require('../../../src/services/proxy/validators');
+const assert = require('node:assert').strict;
+
+describe('Validators', function () {
+    describe('validateQueryParams', function () {
+        it('should throw an error if the token is not provided', function () {
+            const request = {query: {token: ''}};
+            assert.throws(() => validateQueryParams(request), Error);
+        });
+
+        it('should throw an error if the name is not provided', function () {
+            const request = {query: {token: 'abc123', name: ''}};
+            assert.throws(() => validateQueryParams(request), Error);
+        });
+    });
+
+    describe('validateRequestBody', function () {
+        it('should throw an error if the request body is not provided', function () {
+            const request = {};
+            assert.throws(() => validateRequestBody(request), Error);
+        });
+
+        it('should throw an error if the request body is empty', function () {
+            const request = {body: {}};
+            assert.throws(() => validateRequestBody(request), Error);
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4435,7 +4435,7 @@ simple-update-notifier@^2.0.0:
   dependencies:
     semver "^7.5.3"
 
-sinon@20.0.0:
+sinon@^20.0.0:
   version "20.0.0"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-20.0.0.tgz#4b653468735f7152ba694d05498c2b5d024ab006"
   integrity sha512-+FXOAbdnj94AQIxH0w1v8gzNxkawVvNqE3jUzRLptR71Oykeu2RrQXXl/VQjKay+Qnh73fDt/oDfMo6xMeDQbQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,6 +305,847 @@
     lodash.get "^4.4.2"
     type-detect "^4.1.0"
 
+"@stdlib/array-float32@^0.2.1", "@stdlib/array-float32@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-float32/-/array-float32-0.2.2.tgz#88dcbb6cb138da3f3b4bc565423a0afc4dec4e1b"
+  integrity sha512-pTcy1FNQrrJLL1LMxJjuVpcKJaibbGCFFTe41iCSXpSOC8SuTBuNohrO6K9+xR301Ruxxn4yrzjJJ6Fa3nQJ2g==
+  dependencies:
+    "@stdlib/assert-has-float32array-support" "^0.2.2"
+
+"@stdlib/array-float64@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-float64/-/array-float64-0.2.2.tgz#66b3a6fd0e030da1b3d9ba195b865791486ec3a7"
+  integrity sha512-ZmV5wcacGrhT0maw9dfLXNv4N3ZwFUV3D7ItFfZFGFnKIJbubrWzwtaYnxzIXigrDc8g3F6FVHRpsQLMxq0/lA==
+  dependencies:
+    "@stdlib/assert-has-float64array-support" "^0.2.2"
+
+"@stdlib/array-int16@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-int16/-/array-int16-0.2.2.tgz#00855f829f68aad659049de86b9180c662b1f6a7"
+  integrity sha512-kHxyQ1INGtga38Grr/5MnDVAuJgnerh+MsJQcpT5jxxnc9QAnVc7O6DRv8i/hfOOxUOH15C/MeoBs+zim4CnLQ==
+  dependencies:
+    "@stdlib/assert-has-int16array-support" "^0.2.2"
+
+"@stdlib/array-int32@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-int32/-/array-int32-0.2.2.tgz#50b6b6cf8e5f4a11a8c3bcec22dd41e26d2b95a8"
+  integrity sha512-+jFqht43oPJ8YnlyCZ7cSf9Z8xenIIsJDgLZ9zW+gh8o13SSfF+ukm0AGAdnKnKGR3zPBLnSso7JXyDe2r134g==
+  dependencies:
+    "@stdlib/assert-has-int32array-support" "^0.2.2"
+
+"@stdlib/array-int8@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-int8/-/array-int8-0.2.2.tgz#ca1adf97fe04ab1f4c87a608d04a0273d7c42d91"
+  integrity sha512-UW3KlKt7Lww1XML5Gzj+YYHRXD8+RIUrnlPcTwYH9O8j+/m5vyvGYlBIJD2MDO1fgUl2skgmpNkK9ULfsBlIRA==
+  dependencies:
+    "@stdlib/assert-has-int8array-support" "^0.2.2"
+
+"@stdlib/array-uint16@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-uint16/-/array-uint16-0.2.2.tgz#d9647ec67f86dcb032b4e72659df818874498959"
+  integrity sha512-z5c/Izw43HkKfb1pTgEUMAS8GFvhtHkkHZSjX3XJN+17P0VjknxjlSvPiCBGqaDX9jXtlWH3mn1LSyDKtJQoeA==
+  dependencies:
+    "@stdlib/assert-has-uint16array-support" "^0.2.2"
+
+"@stdlib/array-uint32@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-uint32/-/array-uint32-0.2.2.tgz#0e772f971706e7060fa1878f81b0fe05b86c8f07"
+  integrity sha512-3T894I9C2MqZJJmRCYFTuJp4Qw9RAt+GzYnVPyIXoK1h3TepUXe9VIVx50cUFIibdXycgu0IFGASeAb3YMyupw==
+  dependencies:
+    "@stdlib/assert-has-uint32array-support" "^0.2.2"
+
+"@stdlib/array-uint8@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-uint8/-/array-uint8-0.2.2.tgz#4add6fc8fd574c6330a6162aac1ebb421f8a0a82"
+  integrity sha512-Ip9MUC8+10U9x0crMKWkpvfoUBBhWzc6k5SI4lxx38neFVmiJ3f+5MBADEagjpoKSBs71vlY2drnEZe+Gs2Ytg==
+  dependencies:
+    "@stdlib/assert-has-uint8array-support" "^0.2.2"
+
+"@stdlib/array-uint8c@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-uint8c/-/array-uint8c-0.2.2.tgz#91c79bdf4d755c08b8fc6c9ff150216ee0fb9d86"
+  integrity sha512-uBEJ1yKLZjwgmCV7iSNLkr/SGCxL7qVwnb+f4avVSBxlIv/k29oIO/sibgkHbZMBlBSw39dWQzIKD0UQJWDVDQ==
+  dependencies:
+    "@stdlib/assert-has-uint8clampedarray-support" "^0.2.2"
+
+"@stdlib/assert-has-float32array-support@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-float32array-support/-/assert-has-float32array-support-0.2.2.tgz#dacf3439d9a91be30c5637144a2f9afc342ef258"
+  integrity sha512-pi2akQl8mVki43fF1GNQVLYW0bHIPp2HuRNThX9GjB3OFQTpvrV8/3zPSh4lOxQa5gRiabgf0+Rgeu3AOhEw9A==
+  dependencies:
+    "@stdlib/assert-is-float32array" "^0.2.2"
+    "@stdlib/constants-float64-pinf" "^0.2.2"
+
+"@stdlib/assert-has-float64array-support@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-float64array-support/-/assert-has-float64array-support-0.2.2.tgz#228ed3c8a174c4a467b6daccb24b6c9c307cbab5"
+  integrity sha512-8L3GuKY1o0dJARCOsW9MXcugXapaMTpSG6dGxyNuUVEvFfY5UOzcj9/JIDal5FjqSgqVOGL5qZl2qtRwub34VA==
+  dependencies:
+    "@stdlib/assert-is-float64array" "^0.2.2"
+
+"@stdlib/assert-has-int16array-support@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-int16array-support/-/assert-has-int16array-support-0.2.2.tgz#8cec13b0406e9e361861e44cbb9246a6bfdf5af8"
+  integrity sha512-rIrJ2371vd4kg5sHb/bz0xX1dlwyElT6kivnFPtZUXMaMS1breSUIpwPkUPXdr1AbmQdeJYv0c/YBtKB0PCo2g==
+  dependencies:
+    "@stdlib/assert-is-int16array" "^0.2.2"
+    "@stdlib/constants-int16-max" "^0.2.2"
+    "@stdlib/constants-int16-min" "^0.2.2"
+
+"@stdlib/assert-has-int32array-support@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-int32array-support/-/assert-has-int32array-support-0.2.2.tgz#bab04f3378db0ad45b85898a7fd3c240b7dbdab9"
+  integrity sha512-3o/6PuZ+z6+cimb9L1f0d4LGP2GJO4EUVlD6oz8I6vKz35438coM5CduXOMVWvdzm4Rku4ty5mi1Gz0U53pC4Q==
+  dependencies:
+    "@stdlib/assert-is-int32array" "^0.2.2"
+    "@stdlib/constants-int32-max" "^0.3.0"
+    "@stdlib/constants-int32-min" "^0.2.2"
+
+"@stdlib/assert-has-int8array-support@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-int8array-support/-/assert-has-int8array-support-0.2.2.tgz#3995dbcd3beb62f579c474adc9c6e8dbb0bf3695"
+  integrity sha512-QUasYxAqQdgqDglQTwV9dZSwMXvLzLpVC4FcN+kia/+nX1HGjYUBq95fBj0vigW+SC2OiuepJkNiB/PlhA08+g==
+  dependencies:
+    "@stdlib/assert-is-int8array" "^0.2.2"
+    "@stdlib/constants-int8-max" "^0.2.2"
+    "@stdlib/constants-int8-min" "^0.2.2"
+
+"@stdlib/assert-has-node-buffer-support@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-node-buffer-support/-/assert-has-node-buffer-support-0.2.2.tgz#cb6b1a2a2927ef40dc4c8368a6c0d36854ccb70f"
+  integrity sha512-9ReyJGYe9BEZXbUxeRBima0nYy6GwFLVBj7eQ+UUzfG8w7LYYUCpWk954yDpd0v/u+XZQvp1M8EQC2gJLd/i0g==
+  dependencies:
+    "@stdlib/assert-is-buffer" "^0.2.2"
+
+"@stdlib/assert-has-own-property@^0.2.1", "@stdlib/assert-has-own-property@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-own-property/-/assert-has-own-property-0.2.2.tgz#072661539bb79c353dc5e62ae9252ce428adb5f1"
+  integrity sha512-m5rV4Z2/iNkwx2vRsNheM6sQZMzc8rQQOo90LieICXovXZy8wA5jNld4kRKjMNcRt/TjrNP7i2Rhh8hruRDlHg==
+
+"@stdlib/assert-has-symbol-support@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-symbol-support/-/assert-has-symbol-support-0.2.2.tgz#ed7abecb6ae513c5f52dbd14d4601f3d707ab19f"
+  integrity sha512-vCsGGmDZz5dikGgdF26rIL0y0nHvH7qaVf89HLLTybceuZijAqFSJEqcB3Gpl5uaeueLNAWExHi2EkoUVqKHGg==
+
+"@stdlib/assert-has-tostringtag-support@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-tostringtag-support/-/assert-has-tostringtag-support-0.2.2.tgz#4e5053b69571aca325b9ccf26f8e6acbf8190acb"
+  integrity sha512-bSHGqku11VH0swPEzO4Y2Dr+lTYEtjSWjamwqCTC8udOiOIOHKoxuU4uaMGKJjVfXG1L+XefLHqzuO5azxdRaA==
+  dependencies:
+    "@stdlib/assert-has-symbol-support" "^0.2.1"
+
+"@stdlib/assert-has-uint16array-support@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-uint16array-support/-/assert-has-uint16array-support-0.2.2.tgz#b94f9adf53292151129e46a4f2aae2629c679a86"
+  integrity sha512-aL188V7rOkkEH4wYjfpB+1waDO4ULxo5ppGEK6X0kG4YiXYBL2Zyum53bjEQvo0Nkn6ixe18dNzqqWWytBmDeg==
+  dependencies:
+    "@stdlib/assert-is-uint16array" "^0.2.1"
+    "@stdlib/constants-uint16-max" "^0.2.2"
+
+"@stdlib/assert-has-uint32array-support@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-uint32array-support/-/assert-has-uint32array-support-0.2.2.tgz#d5b70c4c068cff8dec176fcd71868690e47abee9"
+  integrity sha512-+UHKP3mZOACkJ9CQjeKNfbXHm5HGQB862V5nV5q3UQlHPzhslnXKyG1SwAxTx+0g88C/2vlDLeqG8H4TH2UTFA==
+  dependencies:
+    "@stdlib/assert-is-uint32array" "^0.2.1"
+    "@stdlib/constants-uint32-max" "^0.2.2"
+
+"@stdlib/assert-has-uint8array-support@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-uint8array-support/-/assert-has-uint8array-support-0.2.2.tgz#33af366594a8540a643360763aada11a1d837075"
+  integrity sha512-VfzrB0BMik9MvPyKcMDJL3waq4nM30RZUrr2EuuQ/RbUpromRWSDbzGTlRq5SfjtJrHDxILPV3rytDCc03dgWA==
+  dependencies:
+    "@stdlib/assert-is-uint8array" "^0.2.1"
+    "@stdlib/constants-uint8-max" "^0.2.2"
+
+"@stdlib/assert-has-uint8clampedarray-support@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-uint8clampedarray-support/-/assert-has-uint8clampedarray-support-0.2.2.tgz#8b1ee4ab857b19747290f4448ac9a69e2ec5695f"
+  integrity sha512-/zT8Piv1UUFUpelBo0LuTE4V9BOEW7DTwfGlPvez93lk72XtaIYhTHkj+Z9YBGfAMV2PbL6eteqFffMVzUgnXg==
+  dependencies:
+    "@stdlib/assert-is-uint8clampedarray" "^0.2.1"
+
+"@stdlib/assert-is-arguments@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-arguments/-/assert-is-arguments-0.2.2.tgz#32e13d3723987d13afb580840a56835e24142aab"
+  integrity sha512-SejXrHpneNcn0nDot2K49XoTzPQQUvCFQj+2vc4UtJdtFFzB5r1fYgvtL7RqkhVglD7zNJG1acJYa7PiZCpZog==
+  dependencies:
+    "@stdlib/assert-has-own-property" "^0.2.2"
+    "@stdlib/assert-is-array" "^0.2.2"
+    "@stdlib/assert-is-enumerable-property" "^0.2.2"
+    "@stdlib/constants-uint32-max" "^0.2.2"
+    "@stdlib/math-base-assert-is-integer" "^0.2.5"
+    "@stdlib/utils-native-class" "^0.2.2"
+
+"@stdlib/assert-is-array@^0.2.1", "@stdlib/assert-is-array@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-array/-/assert-is-array-0.2.2.tgz#ba820d24dd914fe8c29bd61033417ab5a2c2c34f"
+  integrity sha512-aJyTX2U3JqAGCATgaAX9ygvDHc97GCIKkIhiZm/AZaLoFHPtMA1atQ4bKcefEC8Um9eefryxTHfFPfSr9CoNQQ==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-is-boolean@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-boolean/-/assert-is-boolean-0.2.2.tgz#1d6361f66a25cd81ae12085da6ce1457311758ee"
+  integrity sha512-3KFLRTYZpX6u95baZ6PubBvjehJs2xBU6+zrenR0jx8KToUYCnJPxqqj7JXRhSD+cOURmcjj9rocVaG9Nz18Pg==
+  dependencies:
+    "@stdlib/assert-has-tostringtag-support" "^0.2.2"
+    "@stdlib/boolean-ctor" "^0.2.2"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.2"
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-is-buffer@^0.2.1", "@stdlib/assert-is-buffer@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-buffer/-/assert-is-buffer-0.2.2.tgz#f32894cc86103c151e144cf3dbac63ef9e3f8f15"
+  integrity sha512-4/WMFTEcDYlVbRhxY8Wlqag4S70QCnn6WmQ4wmfiLW92kqQHsLvTNvdt/qqh/SDyDV31R/cpd3QPsVN534dNEA==
+  dependencies:
+    "@stdlib/assert-is-object-like" "^0.2.1"
+
+"@stdlib/assert-is-collection@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-collection/-/assert-is-collection-0.2.2.tgz#398c8138202c2334a32254edb00ea74a614c6768"
+  integrity sha512-tbh6ySMqzTkHjFzcNkwtfnJgt65qWeu+0Wv3N0D9QEd3gnJfWq4mJJS3DyJ5n91VoB7RXppB/giDxDUCw/Y+KQ==
+  dependencies:
+    "@stdlib/constants-array-max-typed-array-length" "^0.2.2"
+    "@stdlib/math-base-assert-is-integer" "^0.2.5"
+
+"@stdlib/assert-is-enumerable-property@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-enumerable-property/-/assert-is-enumerable-property-0.2.2.tgz#c6f6460ea0a01712bc8bca26049523294e13d486"
+  integrity sha512-An5QM9Zb3bjKZp5XVdsHTv6/8pJMJvnweHDdLPQhEtLve3YIM4Xo0CQ3TlvKgTr6Lz2UO/+yx8rrDdN5i9Dp5Q==
+  dependencies:
+    "@stdlib/assert-is-integer" "^0.2.2"
+    "@stdlib/assert-is-nan" "^0.2.2"
+    "@stdlib/assert-is-string" "^0.2.2"
+
+"@stdlib/assert-is-error@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-error/-/assert-is-error-0.2.2.tgz#07e56ad03cb55ac8630dd8ecac842e00568e8182"
+  integrity sha512-HKw/vTJvXG8OvDSWSRA5nCKAgKxvzG7xack0xjCUTw1Xh3q8mMmQtCTjwkRtFyvSFDd0DeacMc/Ur5sU5bzOgg==
+  dependencies:
+    "@stdlib/utils-get-prototype-of" "^0.2.1"
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-is-float32array@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-float32array/-/assert-is-float32array-0.2.2.tgz#8b6187136f95e3ef8ba8acad33197736e4844bfb"
+  integrity sha512-hxEKz/Y4m1NYuOaiQKoqQA1HeAYwNXFqSk3FJ4hC71DuGNit2tuxucVyck3mcWLpLmqo0+Qlojgwo5P9/C/9MQ==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-is-float64array@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-float64array/-/assert-is-float64array-0.2.2.tgz#c69a894d85a0a9c71f8b68b3aea1ea35bd3ebe85"
+  integrity sha512-3R1wLi6u/IHXsXMtaLnvN9BSpqAJ8tWhwjOOr6kadDqCWsU7Odc7xKLeAXAInAxwnV8VDpO4ifym4A3wehazPQ==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-is-function@^0.2.1", "@stdlib/assert-is-function@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-function/-/assert-is-function-0.2.2.tgz#97b54f449e54fd15913054cc69c7385ea9baab81"
+  integrity sha512-whY69DUYWljCJ79Cvygp7VzWGOtGTsh3SQhzNuGt+ut6EsOW+8nwiRkyBXYKf/MOF+NRn15pxg8cJEoeRgsPcA==
+  dependencies:
+    "@stdlib/utils-type-of" "^0.2.1"
+
+"@stdlib/assert-is-int16array@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-int16array/-/assert-is-int16array-0.2.2.tgz#2358c371ff651231a3d0ccf4a0cd1edf13cfef77"
+  integrity sha512-HQ9yyX1di07pWreBk6njw9x1sipJKSP4SCSkidLfUHKxaooxeUprAFONfMiEMdNBbn7f3awfs23h1bpN/Z6Vmg==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-is-int32array@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-int32array/-/assert-is-int32array-0.2.2.tgz#64a948b9b23b0943c39930d4e59f55e2917715c4"
+  integrity sha512-YomgTwoJD/ci8K9mWNCyqSDtkYfHNplMYw+B9rmcxrjX//1LVZkrzgwWEc6dC3RlY0Ou+uDHJpKeKL9G2fj4GQ==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-is-int8array@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-int8array/-/assert-is-int8array-0.2.2.tgz#9fc5063c8a3ed70feee357fe3b8fa01bde376e89"
+  integrity sha512-Y1QP3uIZ+CG+rFrD6nOO/N/8O1rRbXgG+iVo5aj8xNRUtfg1iYekUspfNKqxeZUJ95Ocv705m7/vsGlvI1MugQ==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-is-integer@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-integer/-/assert-is-integer-0.2.2.tgz#2b0b76e11926b7530b510c80e2f3e3fdf271a368"
+  integrity sha512-2d4CioQmnPcNDvNfC3Q6+xAJLwYYcSUamnxP0bSBJ1oAazWaVArdXNUAUxufek2Uaq6TVIM2gNSMyivIKIJd2w==
+  dependencies:
+    "@stdlib/assert-is-number" "^0.2.2"
+    "@stdlib/constants-float64-ninf" "^0.2.2"
+    "@stdlib/constants-float64-pinf" "^0.2.2"
+    "@stdlib/math-base-assert-is-integer" "^0.2.4"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.2"
+
+"@stdlib/assert-is-nan@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-nan/-/assert-is-nan-0.2.2.tgz#8d1a65a4ea0c5db87dadb0778bb1eef97b007826"
+  integrity sha512-Wh7KPIVfi6UVBRuPgkjVnoJP6mVtDNg+Y4m3Hko86TSf78KqFXfyZy/m6hnlYBWZRkNJDKo1J/7A/zpPwcEUVg==
+  dependencies:
+    "@stdlib/assert-is-number" "^0.2.2"
+    "@stdlib/math-base-assert-is-nan" "^0.2.1"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.2"
+
+"@stdlib/assert-is-nonnegative-integer@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-nonnegative-integer/-/assert-is-nonnegative-integer-0.2.2.tgz#c47a7afabede723bfc05ed02b28a590163ec03f9"
+  integrity sha512-4t2FoZQeZ5nMYHYSeTVlgAp/HLEMYqe9qMcJgbvj63KTrGCDsuIpTE0S+UTxAc6Oc3Ftgb0ygjBFJQ0mxwN0Ow==
+  dependencies:
+    "@stdlib/assert-is-integer" "^0.2.2"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.2"
+
+"@stdlib/assert-is-number@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-number/-/assert-is-number-0.2.2.tgz#269ab5bf779a26a2cec7575c9a47e163f5bb74b2"
+  integrity sha512-sWpJ59GqGbmlcdYSUV/OYkmQW8k47w10+E0K0zPu1x1VKzhjgA5ZB2sJcpgI8Vt3ckRLjdhuc62ZHJkrJujG7A==
+  dependencies:
+    "@stdlib/assert-has-tostringtag-support" "^0.2.2"
+    "@stdlib/number-ctor" "^0.2.2"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.2"
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-is-object-like@^0.2.1", "@stdlib/assert-is-object-like@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-object-like/-/assert-is-object-like-0.2.2.tgz#3bd47386addeb7ccb4ac82b9d924ddaa5fddde57"
+  integrity sha512-MjQBpHdEebbJwLlxh/BKNH8IEHqY0YlcCMRKOQU0UOlILSJg0vG+GL4fDDqtx9FSXxcTqC+w3keHx8kAKvQhzg==
+  dependencies:
+    "@stdlib/assert-tools-array-function" "^0.2.1"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.2"
+
+"@stdlib/assert-is-object@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-object/-/assert-is-object-0.2.2.tgz#671297efc43788aa5368ce59ede28a8089387a7f"
+  integrity sha512-sNnphJuHyMDHHHaonlx6vaCKMe4sHOn0ag5Ck4iW3kJtM2OZB2J4h8qFcwKzlMk7fgFu7vYNGCZtpm1dYbbUfQ==
+  dependencies:
+    "@stdlib/assert-is-array" "^0.2.1"
+
+"@stdlib/assert-is-plain-object@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-plain-object/-/assert-is-plain-object-0.2.2.tgz#90b67c33ec6430ee5ca5a4c053ef5843550a3435"
+  integrity sha512-o4AFWgBsSNzZAOOfIrxoDFYTqnLuGiaHDFwIeZGUHdpQeav2Fll+sGeaqOcekF7yKawoswnwWdJqTsjapb4Yzw==
+  dependencies:
+    "@stdlib/assert-has-own-property" "^0.2.1"
+    "@stdlib/assert-is-function" "^0.2.1"
+    "@stdlib/assert-is-object" "^0.2.1"
+    "@stdlib/utils-get-prototype-of" "^0.2.1"
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-is-regexp@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-regexp/-/assert-is-regexp-0.2.2.tgz#4d0f24c5ab189da3839ceca7e6955d263d7b798d"
+  integrity sha512-2JtiUtRJxPaVXL7dkWoV3n5jouI65DwYDXsDXg3xo23TXlTNGgU/HhKO4FWC1Yqju7YMZi0hcZSW6E9v8ISqeQ==
+  dependencies:
+    "@stdlib/assert-has-tostringtag-support" "^0.2.2"
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-is-string@^0.2.1", "@stdlib/assert-is-string@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-string/-/assert-is-string-0.2.2.tgz#2f3099045f5c9bdb85bf7620c021c17e5be19f2f"
+  integrity sha512-SOkFg4Hq443hkadM4tzcwTHWvTyKP9ULOZ8MSnnqmU0nBX1zLVFLFGY8jnF6Cary0dL0V7QQBCfuxqKFM6u2PQ==
+  dependencies:
+    "@stdlib/assert-has-tostringtag-support" "^0.2.2"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.2"
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-is-uint16array@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-uint16array/-/assert-is-uint16array-0.2.2.tgz#85346d95d8fd08c879a0b33a210d9224f54a2d4b"
+  integrity sha512-w3+HeTiXGLJGw5nCqr0WbvgArNMEj7ulED1Yd19xXbmmk2W1ZUB+g9hJDOQTiKsTU4AVyH4/As+aA8eDVmWtmg==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-is-uint32array@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-uint32array/-/assert-is-uint32array-0.2.2.tgz#37f35526101e5847c54cb8c9952976d1888a0bb8"
+  integrity sha512-3F4nIHg1Qp0mMIsImWUC8DwQ3qBK5vdIJTjS2LufLbFBhHNmv5kK1yJiIXQDTLkENU0STZe05TByo01ZNLOmDQ==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-is-uint8array@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-uint8array/-/assert-is-uint8array-0.2.2.tgz#2d46b13d58b8d1b6aa4e4841fbb6903c6cd07a08"
+  integrity sha512-51WnDip6H2RrN0CbqWmfqySAjam8IZ0VjlfUDc3PtcgrZGrKKjVgyHAsT/L3ZDydwF+aB94uvYJu5QyrCPNaZw==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-is-uint8clampedarray@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-uint8clampedarray/-/assert-is-uint8clampedarray-0.2.2.tgz#3b4cbbe0c74326967fe868ab1d1288ce02cbbc83"
+  integrity sha512-MjHhOxjOXesqUNgoDGOiO9vib1HV3uCNoYQfiEDWAv30pVAty70wEcwDQ7cdQs1ZGfGC/355ob8AR2Z8lY4ryw==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/assert-tools-array-function@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-tools-array-function/-/assert-tools-array-function-0.2.2.tgz#aba9b71b5164e97872cd2d6b16b221e01bd8c5e0"
+  integrity sha512-FYeT7X9x0C8Nh+MN6IJUDz+7i7yB6mio2/SDlrvyepjyPSU/cfHfwW0GEOnQhxZ+keLZC/YqDD930WjRODwMdA==
+  dependencies:
+    "@stdlib/assert-is-array" "^0.2.1"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.2"
+    "@stdlib/string-format" "^0.2.2"
+
+"@stdlib/boolean-ctor@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/boolean-ctor/-/boolean-ctor-0.2.2.tgz#d0add4760adeca22631625dd95bb9ca32abb931a"
+  integrity sha512-qIkHzmfxDvGzQ3XI9R7sZG97QSaWG5TvWVlrvcysOGT1cs6HtQgnf4D//SRzZ52VLm8oICP+6OKtd8Hpm6G7Ww==
+
+"@stdlib/buffer-ctor@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/buffer-ctor/-/buffer-ctor-0.2.2.tgz#8469a6d301b4b11e08763b3238b949b2aa132841"
+  integrity sha512-Q/FkXxyZUzCA1fwOl7sa8ZYg6e60fTksCYr01nJv8fvmr9l9Ju6MKmm20n833yE7KA5jDDtZW9lB1V7552fLMA==
+  dependencies:
+    "@stdlib/assert-has-node-buffer-support" "^0.2.1"
+
+"@stdlib/buffer-from-buffer@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/buffer-from-buffer/-/buffer-from-buffer-0.2.2.tgz#10e277a9856f457017f78ada38177b7dd2178e98"
+  integrity sha512-EU/Mju7j3Hw/z6xxlZ14h6ZEyhiarR4nXhDQwycJ4NcFb7Oi+KaeNvX5rRQgf/k04cpcq8VkQiM1xOMrKPCvqA==
+  dependencies:
+    "@stdlib/assert-is-buffer" "^0.2.2"
+    "@stdlib/assert-is-function" "^0.2.2"
+    "@stdlib/buffer-ctor" "^0.2.2"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.2"
+    "@stdlib/string-format" "^0.2.2"
+
+"@stdlib/complex-float32-ctor@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/complex-float32-ctor/-/complex-float32-ctor-0.0.2.tgz#57f6d3f0217c1ae1f83ea12b044a80e951a215d3"
+  integrity sha512-QsTLynhTRmDT0mSkfdHj0FSqQSxh2nKx+vvrH3Y0/Cd/r0WoHFZwyibndDxshfkf9B7nist8QKyvV82I3IZciA==
+  dependencies:
+    "@stdlib/assert-is-number" "^0.2.2"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.2"
+    "@stdlib/number-float64-base-to-float32" "^0.2.1"
+    "@stdlib/string-format" "^0.2.2"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.2"
+    "@stdlib/utils-define-property" "^0.2.4"
+
+"@stdlib/complex-float32-reim@^0.1.1":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/complex-float32-reim/-/complex-float32-reim-0.1.2.tgz#095fcd9e4c2657d58c294eeeaeb5d46591d844bc"
+  integrity sha512-24H+t1xwQF6vhOoMZdDA3TFB4M+jb5Swm/FwNaepovlzVIG2NlthUZs6mZg1T3oegqesIRQRwhpn4jIPjuGiTw==
+  dependencies:
+    "@stdlib/array-float32" "^0.2.2"
+    "@stdlib/complex-float32-ctor" "^0.0.2"
+
+"@stdlib/complex-float64-ctor@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/complex-float64-ctor/-/complex-float64-ctor-0.0.3.tgz#740fdb24f5d1d5db82fa7800b91037e552a47bb6"
+  integrity sha512-oixCtBif+Uab2rKtgedwQTbQTEC+wVSu4JQH935eJ8Jo0eL6vXUHHlVrkLgYKlCDLvq5px1QQn42Czg/ixh6Gw==
+  dependencies:
+    "@stdlib/assert-is-number" "^0.2.2"
+    "@stdlib/complex-float32-ctor" "^0.0.2"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.2"
+    "@stdlib/string-format" "^0.2.2"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.2"
+    "@stdlib/utils-define-property" "^0.2.4"
+
+"@stdlib/complex-float64-reim@^0.1.1":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/complex-float64-reim/-/complex-float64-reim-0.1.2.tgz#22276ea7feef9d61c5bc0d4b0d0137386c57960e"
+  integrity sha512-q6RnfgbUunApAYuGmkft1oOM3x3xVMVJwNRlRgfIXwKDb8pYt+S/CeIwi3Su5SF6ay3AqA1s+ze7m21osXAJyw==
+  dependencies:
+    "@stdlib/array-float64" "^0.2.2"
+    "@stdlib/complex-float64-ctor" "^0.0.3"
+
+"@stdlib/constants-array-max-typed-array-length@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-array-max-typed-array-length/-/constants-array-max-typed-array-length-0.2.2.tgz#1cf750d8f0732a88159f2bc6a9c881fcb816add0"
+  integrity sha512-uAoBItVIfuzR4zKK1F57Znrn2frKL0U9gqJkg30BXuno3YlUvbhIfVP3VsUmGJCmi9ztgYLqX10yqb0KvlM2Ig==
+
+"@stdlib/constants-float64-ninf@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-ninf/-/constants-float64-ninf-0.2.2.tgz#d7f5c5d445701dca25d39c14cac7a17acd7c5ee0"
+  integrity sha512-Iu+wZs/vgudAKVg9FEcRY3FadkmvsWuq/wJ3jIHjhaP5xcnoF3XJUO4IneEndybHwehfJL65NShnDsJcg1gicw==
+  dependencies:
+    "@stdlib/number-ctor" "^0.2.2"
+
+"@stdlib/constants-float64-pinf@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-pinf/-/constants-float64-pinf-0.2.2.tgz#e568ccfc63f8788f48acb55821bc9f0a7403ec5d"
+  integrity sha512-UcwnWaSkUMD8QyKADwkXPlY7yOosCPZpE2EDXf/+WOzuWi5vpsec+JaasD5ggAN8Rv8OTVmexTFs1uZfrHgqVQ==
+
+"@stdlib/constants-int16-max@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-int16-max/-/constants-int16-max-0.2.2.tgz#151a4ba8cd09176f201c308e0d5bc15100b94043"
+  integrity sha512-w7XnWFxYXRyAnbKOxur3981FeaSlhKvHlhETwH5ZhtOQerk3Jn/iJFdtbN8CD0he1Kml4DWhnoKB7P9PcOaTIw==
+
+"@stdlib/constants-int16-min@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-int16-min/-/constants-int16-min-0.2.2.tgz#4e2162619b551f8f552a9625149340e73ac65092"
+  integrity sha512-zn15vCgNoyD97z7mNQMChEneyc6xQudVGj1BOv5vZl827vHAs+KV6xeCI7VGY8Lpd6V22piDoGG3Mvj/43u9vQ==
+
+"@stdlib/constants-int32-max@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-int32-max/-/constants-int32-max-0.3.0.tgz#e575c365738d81b5fa1273877893312d3597af2c"
+  integrity sha512-jYN84QfG/yP2RYw98OR6UYehFFs0PsGAihV6pYU0ey+WF9IOXgSjRP56KMoZ7ctHwl4wsnj9I+qB2tGuEXr+pQ==
+
+"@stdlib/constants-int32-min@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-int32-min/-/constants-int32-min-0.2.2.tgz#5ba8b290dad74a1f5cb4adb49ea59082df537ac9"
+  integrity sha512-4QMOTpo5QykiWp52Wtugu1WK1wV/Bi2Hjj9L97dfZ3BPB1Oa9ykiUZvTsq3GBNCMu2YHPv1ugbV91C3p3bw+Aw==
+
+"@stdlib/constants-int8-max@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-int8-max/-/constants-int8-max-0.2.2.tgz#b92848bf8281e02af0eb4df2e20ef9187952c02a"
+  integrity sha512-zp1L61S/ycOmkILmvuXEKvtXrEJ0QUAwP65sNAWMJOtdT0mhGMfGpXKvCK84TC3+jP5Wk4LU13cgO2bf/pmGTw==
+
+"@stdlib/constants-int8-min@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-int8-min/-/constants-int8-min-0.2.2.tgz#7355f162229b2a774e817f88e4255e753bb5c093"
+  integrity sha512-nxPloZUqbGuyuOPC0U3xQOn9YdyRq2g9uc1dzcw6k0XBhql9mlz9kCbdC74HeMm4K9Dyyb7IlAZLCezdv60s6g==
+
+"@stdlib/constants-uint16-max@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-uint16-max/-/constants-uint16-max-0.2.2.tgz#8bba489909ea11a468a01afe57be912cbce57f56"
+  integrity sha512-qaFXbxgFnAkt73P5Ch7ODb0TsOTg0LEBM52hw6qt7+gTMZUdS0zBAiy5J2eEkTxA9rD9X3nIyUtLf2C7jafNdw==
+
+"@stdlib/constants-uint32-max@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-uint32-max/-/constants-uint32-max-0.2.2.tgz#354b3c0f78ad54ff565087f01d9d8c337af63831"
+  integrity sha512-2G44HQgIKDrh3tJUkmvtz+eM+uwDvOMF+2I3sONcTHacANb+zP7la4LDYiTp+HFkPJyfh/kPapXBiHpissAb1A==
+
+"@stdlib/constants-uint8-max@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-uint8-max/-/constants-uint8-max-0.2.2.tgz#1187e326b5f03d94a72051cace560ef156ac609d"
+  integrity sha512-ZTBQq3fqS/Y4ll6cPY5SKaS266EfmKP9PW3YLJaTELmYIzVo9w2RFtfCqN05G3olTQ6Le9MUEE/C6VFgZNElDQ==
+
+"@stdlib/error-tools-fmtprodmsg@^0.2.1", "@stdlib/error-tools-fmtprodmsg@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/error-tools-fmtprodmsg/-/error-tools-fmtprodmsg-0.2.2.tgz#0b42240fc5131b460f1120b77da8345dd22ee2dd"
+  integrity sha512-2IliQfTes4WV5odPidZFGD5eYDswZrPXob7oOu95Q69ERqImo8WzSwnG2EDbHPyOyYCewuMfM5Ha6Ggf+u944Q==
+
+"@stdlib/fs-exists@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/fs-exists/-/fs-exists-0.2.2.tgz#ccb289c0784f765796c27593abe6e398fb1bbdd2"
+  integrity sha512-uGLqc7izCIam2aTyv0miyktl4l8awgRkCS39eIEvvvnKIaTBF6pxfac7FtFHeEQKE3XhtKsOmdQ/yJjUMChLuA==
+  dependencies:
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.2"
+
+"@stdlib/fs-resolve-parent-path@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/fs-resolve-parent-path/-/fs-resolve-parent-path-0.2.2.tgz#434fa93c067894fea7632aa4b93fba41d7a58cf5"
+  integrity sha512-ZG78ouZc+pdPLtU+sSpYTvbKTiLUgn6NTtlVFYmcmkYRFn+fGOOakwVuhYMcYG6ti10cLD6WzB/YujxIt8f+nA==
+  dependencies:
+    "@stdlib/assert-has-own-property" "^0.2.2"
+    "@stdlib/assert-is-function" "^0.2.2"
+    "@stdlib/assert-is-plain-object" "^0.2.2"
+    "@stdlib/assert-is-string" "^0.2.2"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.2"
+    "@stdlib/fs-exists" "^0.2.2"
+    "@stdlib/process-cwd" "^0.2.2"
+    "@stdlib/string-format" "^0.2.2"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.2"
+
+"@stdlib/math-base-assert-is-integer@^0.2.4", "@stdlib/math-base-assert-is-integer@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-assert-is-integer/-/math-base-assert-is-integer-0.2.5.tgz#fa30a62ee27a90bf5cf598f78d7c0de50b582413"
+  integrity sha512-Zi8N66GbWtSCR3OUsRdBknjNlX+aBN8w6CaVEP5+Jy/a7MgMYzevS52TNS5sm8jqzKBlFhZlPLex+Zl2GlPvSA==
+  dependencies:
+    "@stdlib/math-base-special-floor" "^0.2.3"
+    "@stdlib/utils-library-manifest" "^0.2.2"
+
+"@stdlib/math-base-assert-is-nan@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-assert-is-nan/-/math-base-assert-is-nan-0.2.2.tgz#84289029340e0002a3795e640b7c46be3c3e1696"
+  integrity sha512-QVS8rpWdkR9YmHqiYLDVLsCiM+dASt/2feuTl4T/GSdou3Y/PS/4j/tuDvCDoHDNfDkULUW+FCVjKYpbyoeqBQ==
+  dependencies:
+    "@stdlib/utils-library-manifest" "^0.2.1"
+
+"@stdlib/math-base-napi-unary@^0.2.1":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-napi-unary/-/math-base-napi-unary-0.2.3.tgz#57862685d6ce037aa927020d272e8d74cc243320"
+  integrity sha512-BCyJmpq2S8EFo2yMt1z+v1EL7nn8RHcM6jn7fa8n3BTP679K0MSlawIh3A0CFogfrTdjPM4G44VO1ddsdLExcg==
+  dependencies:
+    "@stdlib/complex-float32-ctor" "^0.0.2"
+    "@stdlib/complex-float32-reim" "^0.1.1"
+    "@stdlib/complex-float64-ctor" "^0.0.3"
+    "@stdlib/complex-float64-reim" "^0.1.1"
+    "@stdlib/utils-library-manifest" "^0.2.2"
+
+"@stdlib/math-base-special-floor@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-floor/-/math-base-special-floor-0.2.3.tgz#978f69d99f298e571cadf00d8d4b92111db4644d"
+  integrity sha512-zTkxVRawtWwJ4NmAT/1e+ZsIoBj1JqUquGOpiNVGNIKtyLOeCONZlZSbN7zuxPkshvmcSjpQ/VLKR8Tw/37E9A==
+  dependencies:
+    "@stdlib/math-base-napi-unary" "^0.2.1"
+    "@stdlib/utils-library-manifest" "^0.2.2"
+
+"@stdlib/number-ctor@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-ctor/-/number-ctor-0.2.2.tgz#64f76c5b5e2adcde7f089e9fd6625881e35a6fb0"
+  integrity sha512-98pL4f1uiXVIw9uRV6t4xecMFUYRRTUoctsqDDV8MSRtKEYDzqkWCNz/auupJFJ135L1ejzkejh73fASsgcwKQ==
+
+"@stdlib/number-float64-base-to-float32@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float64-base-to-float32/-/number-float64-base-to-float32-0.2.2.tgz#5cb3bd9bf59fddd5747d50b5d54913178c562c3a"
+  integrity sha512-T5snDkVNZY6pomrSW/qLWQfZ9JHgqCFLi8jaaarfNj2o+5NMUuvvRifLUIacTm8/uC96xB0j3+wKTh1zbIV5ig==
+  dependencies:
+    "@stdlib/array-float32" "^0.2.1"
+
+"@stdlib/object-ctor@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/object-ctor/-/object-ctor-0.2.1.tgz#a3e261cd65eecffcb03e2cc7472aa5058efba48f"
+  integrity sha512-HEIBBpfdQS9Nh5mmIqMk9fzedx6E0tayJrVa2FD7No86rVuq/Ikxq1QP7qNXm+i6z9iNUUS/lZq7BmJESWO/Zg==
+
+"@stdlib/process-cwd@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/process-cwd/-/process-cwd-0.2.2.tgz#228df717417c335da7eeda37b6cc2b90fc3205f1"
+  integrity sha512-8Q/nA/ud5d5PEzzG6ZtKzcOw+RMLm5CWR8Wd+zVO5vcPj+JD7IV7M2lBhbzfUzr63Torrf/vEhT3cob8vUHV/A==
+
+"@stdlib/regexp-extended-length-path@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/regexp-extended-length-path/-/regexp-extended-length-path-0.2.2.tgz#5ea1664bc07de520236f8ab8201b160c9d9bffcd"
+  integrity sha512-z3jqauEsaxpsQU3rj1A1QnOgu17pyW5kt+Az8QkoTk7wqNE8HhPikI6k4o7XBHV689rSFWZCl4c4W+7JAiNObQ==
+  dependencies:
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.2"
+
+"@stdlib/regexp-function-name@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/regexp-function-name/-/regexp-function-name-0.2.2.tgz#e85e4e94eb382c9c8416b18ffe712c934c2b2b1f"
+  integrity sha512-0z/KRsgHJJ3UQkmBeLH+Nin0hXIeA+Fw1T+mnG2V5CHnTA6FKlpxJxWrvwLEsRX7mR/DNtDp06zGyzMFE/4kig==
+  dependencies:
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.2"
+
+"@stdlib/regexp-regexp@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/regexp-regexp/-/regexp-regexp-0.2.2.tgz#624d7c64529016986ef1493b7db621766b1f74cd"
+  integrity sha512-LlWqVH7wou4rJ2vovmn8ZZf4Z5/sMYxGQkmUcURvdCDMSL4pt91uPMi9I2hLECcIYXLiKUD87VSR56Y5luaafg==
+  dependencies:
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.2.2"
+
+"@stdlib/string-base-format-interpolate@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-base-format-interpolate/-/string-base-format-interpolate-0.2.2.tgz#67c22f0ca93ccffd0eb7e1c7276e487b26e786c6"
+  integrity sha512-i9nU9rAB2+o/RR66TS9iQ8x+YzeUDL1SGiAo6GY3hP6Umz5Dx9Qp/v8T69gWVsb4a1YSclz5+YeCWaFgwvPjKA==
+
+"@stdlib/string-base-format-tokenize@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-base-format-tokenize/-/string-base-format-tokenize-0.2.2.tgz#3ef9e49f6619ce39d9ba8399c9f4f63b3199289a"
+  integrity sha512-kXq2015i+LJjqth5dN+hYnvJXBSzRm8w0ABWB5tYAsIuQTpQK+mSo2muM8JBEFEnqUHAwpUsu2qNTK/9o8lsJg==
+
+"@stdlib/string-base-lowercase@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-base-lowercase/-/string-base-lowercase-0.4.0.tgz#079b55c30be8f2ea5b63c7a24707852e63a8d1b8"
+  integrity sha512-IH35Z5e4T+S3b3SfYY39mUhrD2qvJVp4VS7Rn3+jgj4+C3syocuAPsJ8C4OQXWGfblX/N9ymizbpFBCiVvMW8w==
+
+"@stdlib/string-base-replace@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-base-replace/-/string-base-replace-0.2.2.tgz#d5f8967600d530b2b2938ba1a8c1b333b6be8c1f"
+  integrity sha512-Y4jZwRV4Uertw7AlA/lwaYl1HjTefSriN5+ztRcQQyDYmoVN3gzoVKLJ123HPiggZ89vROfC+sk/6AKvly+0CA==
+
+"@stdlib/string-format@^0.2.1", "@stdlib/string-format@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-format/-/string-format-0.2.2.tgz#5f2ac8cfb06e1b11be9ac8fc546075d0c77ec938"
+  integrity sha512-GUa50uxgMAtoItsxTbMmwkyhIwrCxCrsjzk3nAbLnt/1Kt1EWOWMwsALqZdD6K4V/xSJ4ns6PZur3W6w+vKk9g==
+  dependencies:
+    "@stdlib/string-base-format-interpolate" "^0.2.1"
+    "@stdlib/string-base-format-tokenize" "^0.2.2"
+
+"@stdlib/string-replace@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-replace/-/string-replace-0.2.2.tgz#c4a526abdec7ec031beeb87f98c4c9356fdce969"
+  integrity sha512-czNS5IU7sBuHjac45Y3VWUTsUoi82yc8JsMZrOMcjgSrEuDrVmA6sNJg7HC1DuSpdPjm/v9uUk102s1gIfk3Nw==
+  dependencies:
+    "@stdlib/assert-is-function" "^0.2.2"
+    "@stdlib/assert-is-regexp" "^0.2.2"
+    "@stdlib/assert-is-string" "^0.2.2"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.2"
+    "@stdlib/string-base-replace" "^0.2.2"
+    "@stdlib/string-format" "^0.2.2"
+    "@stdlib/utils-escape-regexp-string" "^0.2.2"
+
+"@stdlib/symbol-ctor@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/symbol-ctor/-/symbol-ctor-0.2.2.tgz#07a1477df50d9c54f4b79f810a0f0667e52c24d6"
+  integrity sha512-XsmiTfHnTb9jSPf2SoK3O0wrNOXMxqzukvDvtzVur1XBKfim9+seaAS4akmV1H3+AroAXQWVtde885e1B6jz1w==
+
+"@stdlib/utils-constructor-name@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-constructor-name/-/utils-constructor-name-0.2.2.tgz#3462fb107196d00698604aac32089353273c82a2"
+  integrity sha512-TBtO3MKDAf05ij5ajmyBCbpKKt0Lfahn5tu18gqds4PkFltgcw5tVZfSHY5DZ2HySJQ2GMMYjPW2Kbg6yPCSVg==
+  dependencies:
+    "@stdlib/assert-is-buffer" "^0.2.1"
+    "@stdlib/regexp-function-name" "^0.2.2"
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/utils-convert-path@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-convert-path/-/utils-convert-path-0.2.2.tgz#7ffcd09a4f2384e0421a4154e31fe520ee0a62b7"
+  integrity sha512-8nNuAgt23Np9NssjShUrPK42c6gRTweGuoQw+yTpTfBR9VQv8WFyt048n8gRGUlAHizrdMNpEY9VAb7IBzpVYw==
+  dependencies:
+    "@stdlib/assert-is-string" "^0.2.2"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.2"
+    "@stdlib/regexp-extended-length-path" "^0.2.2"
+    "@stdlib/string-base-lowercase" "^0.4.0"
+    "@stdlib/string-format" "^0.2.2"
+    "@stdlib/string-replace" "^0.2.1"
+
+"@stdlib/utils-copy@^0.2.0":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-copy/-/utils-copy-0.2.2.tgz#d7359e59de632a0dd1a315feb0ccff7e0c96e42a"
+  integrity sha512-DM8O5tgOHHyhaERDJKa/ThDhIewDyo5SxoFJnmxSriAlJsV9uAmzF8rm7vY969TPRACb+Uxj2GXUoYlmUcHTmA==
+  dependencies:
+    "@stdlib/array-float32" "^0.2.2"
+    "@stdlib/array-float64" "^0.2.2"
+    "@stdlib/array-int16" "^0.2.2"
+    "@stdlib/array-int32" "^0.2.2"
+    "@stdlib/array-int8" "^0.2.2"
+    "@stdlib/array-uint16" "^0.2.2"
+    "@stdlib/array-uint32" "^0.2.2"
+    "@stdlib/array-uint8" "^0.2.2"
+    "@stdlib/array-uint8c" "^0.2.2"
+    "@stdlib/assert-has-own-property" "^0.2.2"
+    "@stdlib/assert-is-array" "^0.2.2"
+    "@stdlib/assert-is-buffer" "^0.2.2"
+    "@stdlib/assert-is-error" "^0.2.2"
+    "@stdlib/assert-is-nonnegative-integer" "^0.2.2"
+    "@stdlib/buffer-from-buffer" "^0.2.2"
+    "@stdlib/constants-float64-pinf" "^0.2.2"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.2"
+    "@stdlib/string-format" "^0.2.2"
+    "@stdlib/utils-define-property" "^0.2.4"
+    "@stdlib/utils-get-prototype-of" "^0.2.2"
+    "@stdlib/utils-index-of" "^0.2.2"
+    "@stdlib/utils-keys" "^0.2.2"
+    "@stdlib/utils-property-descriptor" "^0.2.2"
+    "@stdlib/utils-property-names" "^0.2.2"
+    "@stdlib/utils-regexp-from-string" "^0.2.2"
+    "@stdlib/utils-type-of" "^0.2.2"
+
+"@stdlib/utils-define-nonenumerable-read-only-property@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-define-nonenumerable-read-only-property/-/utils-define-nonenumerable-read-only-property-0.2.2.tgz#80be97888609d1e471d20812cc5ba83a01f92e88"
+  integrity sha512-V3mpAesJemLYDKG376CsmoczWPE/4LKsp8xBvUxCt5CLNAx3J/1W39iZQyA5q6nY1RStGinGn1/dYZwa8ig0Uw==
+  dependencies:
+    "@stdlib/utils-define-property" "^0.2.3"
+
+"@stdlib/utils-define-property@^0.2.3", "@stdlib/utils-define-property@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-define-property/-/utils-define-property-0.2.4.tgz#a8b6e120c829ee99ed81cf0111bb4c76ef85da9e"
+  integrity sha512-XlMdz7xwuw/sqXc9LbsV8XunCzZXjbZPC+OAdf4t4PBw4ZRwGzlTI6WED+f4PYR5Tp9F1cHgLPyMYCIBfA2zRg==
+  dependencies:
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.1"
+    "@stdlib/string-format" "^0.2.1"
+
+"@stdlib/utils-escape-regexp-string@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-escape-regexp-string/-/utils-escape-regexp-string-0.2.2.tgz#dd407c9324c1da4fa7b25e5c862502e8dc6d61ab"
+  integrity sha512-areCibzgpmvm6pGKBg+mXkSDJW4NxtS5jcAT7RtunGMdAYhA/I5whISMPaeJkIT2XhjjFkjKBaIs5pF6aPr4fQ==
+  dependencies:
+    "@stdlib/assert-is-string" "^0.2.1"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.2"
+    "@stdlib/string-format" "^0.2.2"
+
+"@stdlib/utils-get-prototype-of@^0.2.1", "@stdlib/utils-get-prototype-of@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-get-prototype-of/-/utils-get-prototype-of-0.2.2.tgz#a65def101deece8d81f3bbf892ababe4d61114bb"
+  integrity sha512-eDb1BAvt7GW/jduBkfuQrUsA9p09mV8RW20g0DWPaxci6ORYg/UB0tdbAA23aZz2QUoxdYY5s/UJxlq/GHwoKQ==
+  dependencies:
+    "@stdlib/assert-is-function" "^0.2.1"
+    "@stdlib/object-ctor" "^0.2.1"
+    "@stdlib/utils-native-class" "^0.2.1"
+
+"@stdlib/utils-global@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-global/-/utils-global-0.2.2.tgz#61f875ef4ed74a091ed841127262961edef2d973"
+  integrity sha512-A4E8VFHn+1bpfJ4PA8H2b62CMQpjv2A+H3QDEBrouLFWne0wrx0TNq8vH6VYHxx9ZRxhgWQjfHiSAxtUJobrbQ==
+  dependencies:
+    "@stdlib/assert-is-boolean" "^0.2.1"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.2"
+    "@stdlib/string-format" "^0.2.2"
+
+"@stdlib/utils-index-of@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-index-of/-/utils-index-of-0.2.2.tgz#9c60f95bb480dbe5a5107daaf6b12d61da69dc89"
+  integrity sha512-yVnjPk3Arzf3no+Ju5ys4ZVG4aKHA8xV4g53Ni+FO8c0AStKq9F8O+E/aFxluCKqLz6jGLaLea7996e0Hcw9mQ==
+  dependencies:
+    "@stdlib/assert-is-collection" "^0.2.1"
+    "@stdlib/assert-is-integer" "^0.2.2"
+    "@stdlib/assert-is-nan" "^0.2.2"
+    "@stdlib/assert-is-string" "^0.2.2"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.2"
+    "@stdlib/string-format" "^0.2.2"
+
+"@stdlib/utils-keys@^0.2.1", "@stdlib/utils-keys@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-keys/-/utils-keys-0.2.2.tgz#efdd5b14370468d146bb4fdd3819caa0f76699e0"
+  integrity sha512-mvmvhpewElNalx5YotZ/jI57CiYHc9y6N8SGxJiOUs04NkWMkW8rnXRvJEi0rPj2BOIJReEGZ1WaZpdL68DUcQ==
+  dependencies:
+    "@stdlib/assert-has-own-property" "^0.2.2"
+    "@stdlib/assert-is-arguments" "^0.2.1"
+    "@stdlib/assert-is-enumerable-property" "^0.2.2"
+    "@stdlib/assert-is-object-like" "^0.2.2"
+    "@stdlib/utils-index-of" "^0.2.2"
+    "@stdlib/utils-noop" "^0.2.2"
+    "@stdlib/utils-type-of" "^0.2.2"
+
+"@stdlib/utils-library-manifest@^0.2.1", "@stdlib/utils-library-manifest@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-library-manifest/-/utils-library-manifest-0.2.2.tgz#1908504dbdbb665a8b72ff40c4f426afefbd7fd2"
+  integrity sha512-YqzVLuBsB4wTqzdUtRArAjBJoT3x61iop2jFChXexhl6ejV3vDpHcukEEkqIOcJKut+1cG5TLJdexgHNt1C0NA==
+  dependencies:
+    "@stdlib/fs-resolve-parent-path" "^0.2.1"
+    "@stdlib/utils-convert-path" "^0.2.1"
+    debug "^2.6.9"
+    resolve "^1.1.7"
+
+"@stdlib/utils-native-class@^0.2.1", "@stdlib/utils-native-class@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-native-class/-/utils-native-class-0.2.2.tgz#dbb00a84e8c583cdd1bc40b163f1786dc44c4f09"
+  integrity sha512-cSn/FozbEpfR/FlJAoceQtZ8yUJFhZ8RFkbEsxW/7+H4o09yln3lBS0HSfUJISYNtpTNN/2/Fup88vmvwspvwA==
+  dependencies:
+    "@stdlib/assert-has-own-property" "^0.2.1"
+    "@stdlib/assert-has-tostringtag-support" "^0.2.2"
+    "@stdlib/symbol-ctor" "^0.2.2"
+
+"@stdlib/utils-noop@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-noop/-/utils-noop-0.2.2.tgz#527404ec9875f5e45ec295810bc462a32e3ce4d2"
+  integrity sha512-QlHCBCExrFlNFFqDBOvxPeHkvAuMBHsbQYWRjSG2FD6QumEDn9EqBAcJZNr+xYdkw/6SVRJ0ySTyroReg5vcAA==
+
+"@stdlib/utils-property-descriptor@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-property-descriptor/-/utils-property-descriptor-0.2.2.tgz#88d9b55c0a17d22ccd50ad9fbf47544a7b4a1c9a"
+  integrity sha512-iq0jFOOX5OmaOC1uyO8POjWPPA6GxbFFcDzH4QsyhKWN2P5ZDvnKMRfH6TuMmaLEA5vSzeNwGfcBPQMRBRphUg==
+  dependencies:
+    "@stdlib/assert-has-own-property" "^0.2.1"
+
+"@stdlib/utils-property-names@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-property-names/-/utils-property-names-0.2.2.tgz#a24852878f8c7b1d8bfa9288b14f720fac67bf1b"
+  integrity sha512-LlHK467gOxvD6T5yzSy/DnDPzeG00Qj1lrowapAOP7HbGMPvs3RI8Re32IqUke5OE698jXW3tL0VDu6yLi2e1A==
+  dependencies:
+    "@stdlib/object-ctor" "^0.2.1"
+    "@stdlib/utils-keys" "^0.2.1"
+
+"@stdlib/utils-regexp-from-string@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-regexp-from-string/-/utils-regexp-from-string-0.2.2.tgz#0eeac962b9e43f8587b5eaf25a235f4380976fdb"
+  integrity sha512-xvyX44wYAn7DUSTwfIdzohFFo2J+kkzZf1I3cQZr09k8364/1x2Ro7bhPVXX/fEUJ1LbbPF3PAcGa44cvN8Nzg==
+  dependencies:
+    "@stdlib/assert-is-string" "^0.2.1"
+    "@stdlib/error-tools-fmtprodmsg" "^0.2.2"
+    "@stdlib/regexp-regexp" "^0.2.2"
+    "@stdlib/string-format" "^0.2.2"
+
+"@stdlib/utils-type-of@^0.2.1", "@stdlib/utils-type-of@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-type-of/-/utils-type-of-0.2.2.tgz#517de513c043d7c0a48743593be41f67f0d51a9f"
+  integrity sha512-RLGFxPNgY9AtVVrFGdKO6Y3pOd/Ov2WA4O2/czZN/AbgYzbPdoF0KkfvHRIney6k+TtvoyYB8YqZXJ4G88f9BQ==
+  dependencies:
+    "@stdlib/utils-constructor-name" "^0.2.1"
+    "@stdlib/utils-global" "^0.2.2"
+
+"@tryghost/errors@^1.3.7":
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.3.7.tgz#70098602944709d24c749b781ea2300d810c8edb"
+  integrity sha512-VYWtDDxMZHDMgtWb5oSQcLfOTC/p+yLmqXBG172yVf+OgaBvgYm6Y/1B1buDv5ySC/icCs5KUImefv8MjBqsTg==
+  dependencies:
+    "@stdlib/utils-copy" "^0.2.0"
+    uuid "^9.0.0"
+
 "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
@@ -1071,7 +1912,7 @@ dateformat@^4.6.3:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
   integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
-debug@^2.1.3, debug@^2.2.0, debug@^2.6.8:
+debug@^2.1.3, debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -3330,7 +4171,7 @@ resolve-pkg-maps@^1.0.0:
   resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
   integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
 
-resolve@^1.10.0, resolve@^1.11.1, resolve@^1.17.0, resolve@^1.22.2:
+resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.1, resolve@^1.17.0, resolve@^1.22.2:
   version "1.22.10"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
   integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==
@@ -4074,6 +4915,11 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+uuid@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-to-istanbul@^9.0.0:
   version "9.3.0"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-223/add-user-agent-parsing-to-the-proxy

Currently this repo is only a simple HTTP proxy server, but eventually it will need to operate in either "http" mode and/or "batch/queue" mode. To make that transition easier in the future, we should decouple the core business logic (validating and processing requests) from the fastify HTTP proxy server.

This comes with the added benefit of making it easier to unit test each step of the processing in isolation, so we can add all the edge cases in fast unit tests, and reserve the E2E tests for high-level smoke tests to cover the basic expected functionality.

This refactor is just a first step in this direction. There's still more to do to fully decouple our core logic from the HTTP interface, but this is a good start that's better than the current state, which has our core logic closely coupled with the HTTP proxy endpoint.

This refactor introduces a new `proxy` service, composed of two macro level steps: validation and processing. Validation is for checking that the request is valid (e.g. checking that required query parameters are present), while processing is for parsing and enriching the payload that is ultimately sent to the upstream server. 

This pattern makes it fairly simple to add other validation rules and processing steps without much pain. We may add more macro steps in the future (e.g. a final filtering stage after the processing is complete to e.g. filter out bots by user agent).

Opportunities for further refactoring:
- The `proxy` service should ultimately be completely decoupled from the `http` interface, but currently we are passing the `reply` object and directly responding with any errors thrown. In the future, the `proxy` service should just throw errors, and the HTTP server should then handle those errors as appropriate, by e.g. responding 400 with an error message.
- Factor the `filterQueryParams` utility into its own processor, and remove the utils directory.
- Typescript would be nice, to define a strict interface for `validators` and `processors`.
- The `proxy` service itself is difficult to test right now, because it doesn't use dependency injection. We should probably refactor this into a class with DI so we can test it more easily.
- I don't love that processors just change the request object in place — in an ideal world they would be pure functions, but this seems to be the standard pattern in Fastify — the request object itself gets mutated as it passes through its lifecycle. Maybe an opportunity to improve this, but it's not obvious to me how right now.