### PR TITLE
Fixed node_modules volume in docker compose setup

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,7 @@
-name: traffic-analytics-proxy
+name: traffic-analytics
 
 services:
-  traffic-analytics-proxy:
+  proxy-server:
     build:
       context: .
       dockerfile: Dockerfile
@@ -12,6 +12,9 @@ services:
       - 3000:3000
     volumes:
       - .:/app
-      - /app/node_modules
+      - node_modules_volume:/app/node_modules
     env_file:
       - .env
+
+volumes:
+  node_modules_volume:


### PR DESCRIPTION
no issue

- The `node_modules` were out of date despite a fresh build, due to an issue with how the volumes were defined in the compose file.
- This change should fix that