### PR TITLE
Improved UA parsing for browser, os and device

### DIFF
--- a/src/services/proxy/processors.js
+++ b/src/services/proxy/processors.js
@@ -45,6 +45,10 @@ function parseUserAgent(request) {
     } catch (error) {
         request.log.error(error);
         // We should fail silently here, because we don't want to break the proxy for non-critical functionality
+        request.body.payload.meta = {};
+        request.body.payload.meta.os = 'unknown';
+        request.body.payload.meta.browser = 'unknown';
+        request.body.payload.meta.device = 'unknown';
     }
 }
 

--- a/src/services/proxy/processors.js
+++ b/src/services/proxy/processors.js
@@ -1,19 +1,47 @@
 const uap = require('ua-parser-js');
 
+function isBot(userAgentString) {
+    const botPattern = /wget|ahrefsbot|curl|bot|crawler|spider|urllib|bitdiscovery|\+https:\/\/|googlebot/i;
+    return botPattern.test(userAgentString);
+}
+
 function parseUserAgent(request) {
     if (!request.headers['user-agent']) {
         return;
     }
 
     try {
-        const ua = new uap(request.headers['user-agent']);
-        const os = ua.getOS() || {name: 'unknown', version: 'unknown'};
-        const browser = ua.getBrowser() || {name: 'unknown', version: 'unknown', major: 'unknown', type: 'unknown'};
-        const device = ua.getDevice() || {type: 'unknown', vendor: 'unknown', model: 'unknown'};
+        const userAgent = request.headers['user-agent'];
+        const ua = new uap(userAgent);
+        const os = ua.getOS();
+        const browser = ua.getBrowser();
+
+        // Normalize browser name (e.g., "Mobile Safari" -> "Safari")
+        let browserName = browser.name?.toLowerCase() || 'unknown';
+        browserName = browserName.replace(/^mobile\s/, '');
+
+        // Normalize Mac OS and macOS
+        let osName = os.name?.toLowerCase() || 'unknown';
+        if (osName === 'mac os') {
+            osName = 'macos';
+        }
+
+        // Normalize device type
+        let deviceType = 'unknown';
+        if (osName === 'ios') {
+            deviceType = 'mobile-ios';
+        } else if (osName === 'android') {
+            deviceType = 'mobile-android';
+        } else if (['macos', 'windows', 'linux', 'chrome os', 'ubuntu'].includes(osName)) {
+            deviceType = 'desktop';
+        } else if (isBot(userAgent)) {
+            deviceType = 'bot';
+        }
+
         request.body.payload.meta = {};
-        request.body.payload.meta.os = os;
-        request.body.payload.meta.browser = browser;
-        request.body.payload.meta.device = device;
+        request.body.payload.meta.os = osName;
+        request.body.payload.meta.browser = browserName;
+        request.body.payload.meta.device = deviceType;
     } catch (error) {
         request.log.error(error);
         // We should fail silently here, because we don't want to break the proxy for non-critical functionality

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -165,7 +165,7 @@ describe('Fastify App', function () {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            assert.deepEqual(targetRequest.body.payload.meta.os, {name: 'Mac OS', version: '10.15.7'});
+            assert.deepEqual(targetRequest.body.payload.meta.os, 'macos');
         });
 
         it('should parse the browser from the user agent and pass it to the upstream server', async function () {
@@ -177,7 +177,7 @@ describe('Fastify App', function () {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            assert.deepEqual(targetRequest.body.payload.meta.browser, {name: 'Chrome', version: '135.0.0.0', major: '135'});
+            assert.deepEqual(targetRequest.body.payload.meta.browser, 'chrome');
         });
 
         it('should parse the device from the user agent and pass it to the upstream server', async function () {
@@ -189,7 +189,7 @@ describe('Fastify App', function () {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            assert.deepEqual(targetRequest.body.payload.meta.device, {vendor: 'Apple', model: 'Macintosh'});
+            assert.deepEqual(targetRequest.body.payload.meta.device, 'desktop');
         });
     });
 });

--- a/test/services/proxy/processors.test.js
+++ b/test/services/proxy/processors.test.js
@@ -1,23 +1,83 @@
 const {parseUserAgent} = require('../../../src/services/proxy/processors');
 const assert = require('node:assert').strict;
+
 describe('Processors', function () {
     describe('parseUserAgent', function () {
-        it('should parse the user agent', function () {
+        it('should parse a desktop user agent', function () {
             const request = {
                 headers: {
                     'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36'
                 },
                 body: {
                     payload: {}
-                }
+                },
+                log: {error: () => {}}
             };
             parseUserAgent(request);
 
             assert.deepEqual(request.body.payload.meta, {
-                os: {name: 'Mac OS', version: '10.15.7'},
-                browser: {name: 'Chrome', version: '91.0.4472.114', major: '91'},
-                device: {type: undefined, vendor: 'Apple', model: 'Macintosh'}
+                os: 'macos',
+                browser: 'chrome',
+                device: 'desktop'
             });
+        });
+
+        it('should normalize mobile browser names', function () {
+            const request = {
+                headers: {
+                    'user-agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1'
+                },
+                body: {
+                    payload: {}
+                },
+                log: {error: () => {}}
+            };
+            parseUserAgent(request);
+            // ua-parser-js returns 'Mobile Safari' before normalization
+            assert.equal(request.body.payload.meta.browser, 'safari');
+        });
+
+        it('should normalize Mac OS and macOS to macos', function () {
+            const request = {
+                headers: {
+                    'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36'
+                },
+                body: {
+                    payload: {}
+                },
+                log: {error: () => {}}
+            };
+            parseUserAgent(request);
+
+            assert.equal(request.body.payload.meta.os, 'macos');
+        });
+
+        it('should identify obvious bots and set the device to bot', function () {
+            const request = {
+                headers: {
+                    'user-agent': 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+                },
+                body: {
+                    payload: {}
+                },
+                log: {error: () => {}}
+            };
+            parseUserAgent(request);
+
+            assert.equal(request.body.payload.meta.device, 'bot');
+        });
+
+        it('should return early if the user agent is not present', function () {
+            const request = {
+                headers: {},
+                body: {
+                    payload: {}
+                },
+                log: {error: () => {}}
+            };
+            parseUserAgent(request);
+
+            assert.equal(request.body.payload.meta, undefined);
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-223/add-user-agent-parsing-to-the-proxy

- Our UA parsing until now has just been logging the raw output from the `ua-parser-js` library, which doesn't return the browser, os and device in the exact format we want it.
- This commit adds some additional processing on top of what `ua-parser-js` gives us. For example, it consolidates "Mobile Safari" and "Safari" into just "Safari".
- It also adds some _very_ basic bot filtering based on a simple regex test on the raw user agent string, similar to what we're doing in Tinybird currently.
- For now, these values are still logged under `payload.meta`, so we can gain more confidence with this running in a passive mode in production with real world user agents.