### PR TITLE
Moved os, browser and device out of the meta key

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,14 +1,7 @@
 import {FastifyRequest as FastifyRequestBase, FastifyReply as FastifyReplyBase} from 'fastify';
 
-export interface PayloadMeta {
-    os: string;
-    browser: string;
-    device: string;
-}
-
 export interface Payload {
     [key: string]: any;
-    meta?: PayloadMeta;
 }
 
 export interface RequestBody {

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -54,7 +54,7 @@ describe('Fastify App', () => {
         // Set the PROXY_TARGET environment variable before requiring the app
         process.env.PROXY_TARGET = targetUrl;
         process.env.LOG_LEVEL = 'silent';
-        
+
         // Import directly from the source
         const appModule = await import('../src/app');
         app = appModule.default;
@@ -183,7 +183,7 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect(targetRequest.body.payload.meta.os).toBe('macos');
+            expect(targetRequest.body.payload.os).toBe('macos');
         });
 
         it('should parse the browser from the user agent and pass it to the upstream server', async function () {
@@ -195,7 +195,7 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect(targetRequest.body.payload.meta.browser).toBe('chrome');
+            expect(targetRequest.body.payload.browser).toBe('chrome');
         });
 
         it('should parse the device from the user agent and pass it to the upstream server', async function () {
@@ -207,7 +207,7 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect(targetRequest.body.payload.meta.device).toBe('desktop');
+            expect(targetRequest.body.payload.device).toBe('desktop');
         });
     });
-}); 
+});

--- a/test/services/proxy/processors.test.ts
+++ b/test/services/proxy/processors.test.ts
@@ -82,7 +82,7 @@ describe('Processors', () => {
             expect(request.body?.payload.device).toBe('bot');
         });
 
-        it('should return early if the user agent is not present', () => {
+        it('should return unknown values if the user agent is not present', () => {
             const request: Partial<HttpProxyRequest> = {
                 headers: {},
                 body: {
@@ -95,7 +95,11 @@ describe('Processors', () => {
             };
             parseUserAgent(request as FastifyRequest);
 
-            expect(request.body?.payload).toBeUndefined();
+            expect(request.body?.payload).toEqual({
+                os: 'unknown',
+                browser: 'unknown',
+                device: 'unknown'
+            });
         });
     });
 });

--- a/test/services/proxy/processors.test.ts
+++ b/test/services/proxy/processors.test.ts
@@ -21,7 +21,7 @@ describe('Processors', () => {
             };
             parseUserAgent(request as FastifyRequest);
 
-            expect(request.body?.payload.meta).toEqual({
+            expect(request.body?.payload).toEqual({
                 os: 'macos',
                 browser: 'chrome',
                 device: 'desktop'
@@ -43,7 +43,7 @@ describe('Processors', () => {
             };
             parseUserAgent(request as FastifyRequest);
             // ua-parser-js returns 'Mobile Safari' before normalization
-            expect(request.body?.payload.meta?.browser).toBe('safari');
+            expect(request.body?.payload.browser).toBe('safari');
         });
 
         it('should normalize Mac OS and macOS to macos', () => {
@@ -61,7 +61,7 @@ describe('Processors', () => {
             };
             parseUserAgent(request as FastifyRequest);
 
-            expect(request.body?.payload.meta?.os).toBe('macos');
+            expect(request.body?.payload.os).toBe('macos');
         });
 
         it('should identify obvious bots and set the device to bot', () => {
@@ -79,7 +79,7 @@ describe('Processors', () => {
             };
             parseUserAgent(request as FastifyRequest);
 
-            expect(request.body?.payload.meta?.device).toBe('bot');
+            expect(request.body?.payload.device).toBe('bot');
         });
 
         it('should return early if the user agent is not present', () => {
@@ -95,7 +95,7 @@ describe('Processors', () => {
             };
             parseUserAgent(request as FastifyRequest);
 
-            expect(request.body?.payload.meta).toBeUndefined();
+            expect(request.body?.payload).toBeUndefined();
         });
     });
-}); 
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-223/add-user-agent-parsing-to-the-proxy

We've been collecting these fields in the `payload.meta` field for a while to see what kind of data we're getting in the real world. It all looks good to me, so promoting them to top level fields in the payload now. 