### PR TITLE
Fixed eslint config for typescript

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,7 +1,7 @@
 module.exports = {
     plugins: ['ghost', '@typescript-eslint'],
     extends: [
-        'plugin:ghost/node',
+        'plugin:ghost/ts',
         'plugin:@typescript-eslint/recommended'
     ],
     parser: '@typescript-eslint/parser',


### PR DESCRIPTION
no refs

ESlint was throwing some weird errors, like both requiring a semi-colon and not allowing a semi-colon. Being a Typescript codebase, I updated the configuration to use the `ghost/ts` plugin, which fixed these errors.