### PR TITLE
Fixed command for docker compose

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile
       args:
         BUILD_TYPE: development
-    command: ["yarn", "dev"]
+    command: ["yarn", "dev", "--host", "0.0.0.0"]
     ports:
       - 3000:3000
     volumes:


### PR DESCRIPTION
no refs

When running with `docker compose up`, the host isn't set to `0.0.0.0`, so the server isn't reachable from localhost. This commit fixes it by setting the host directly when running the command for the proxy-service in compose.