### PR TITLE
Added support for running the analytics service in Ghost's docker compose network

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Traffic Analytics Service
 - `docker compose up` or `yarn docker:dev` start development server in docker compose
 - View: [http://localhost:3000](http://localhost:3000)
 
+## Run locally with Ghost in Docker
+
+Sometimes it's useful to test the full setup with Ghost pointing its tracker script to this analytics service running locally. This can be acheived relatively easily with Docker Compose:
+- Set the `tinybird:tracker:endpoint` to `http://localhost/.ghost/analytics/tb/web_analytics` in your Ghost config
+- Run `docker compose --profile=split up` in your Ghost clone
+- If you want to test the full e2e flow to Tinybird, set the `PROXY_TARGET=https://api.tinybird.co/v0/events` value in your `.env` file in this repo. Otherwise the analytics service will use the `/local-proxy` mock endpoint, which does not forward events to Tinybird.
+- Run `yarn docker:dev:ghost` in the root of this repo
+- Visit your Ghost site's homepage at `http://localhost` and you should see a successful request in the network tab.
+
 ## Test
 
 - `yarn test` run all tests locally

--- a/compose.ghost.yml
+++ b/compose.ghost.yml
@@ -1,0 +1,13 @@
+name: traffic-analytics
+
+services:
+  analytics-service:
+    networks:
+      - ghost_default
+
+networks:
+  ghost_default:
+    external: true
+
+volumes:
+  node_modules_volume:

--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,7 @@
 name: traffic-analytics
 
 services:
-  server:
+  analytics-service:
     image: local/traffic-analytics:development
     pull_policy: never
     build:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "docker:build": "docker compose build",
     "dev": "vite",
     "docker:dev": "docker compose up",
+    "docker:dev:ghost": "docker compose -f compose.yml -f compose.ghost.yml up",
     "start": "node dist/server.js",
     "pretest": "yarn build",
     "test:unit": "NODE_ENV=testing vitest run --coverage",


### PR DESCRIPTION
no refs

This commit adds the ability to easily run the analytics service side-by-side with Ghost running locally in Docker Compose. This provides a more production-like setup when working on the analytics service.

- Ghost's docker compose setup now has a Caddy route handler to route requests to `/.ghost/analytics` to this service.
- This commit adds a new `compose.ghost.yml`, which can be used in addition to the base `compose.yml` to attach the analytics service to the Docker network from the Ghost project.
- It also adds a convenience command: `yarn docker:dev:ghost` and some documentation to the `README.md` for setting this up.

With this setup, Ghost's tracker script will route requests to `http://localhost/.ghost/analytics/tb/web_analytics`. Ghost's Caddy service will route those requests to the analytics service, which will then forward the events to Tinybird. This is about as close to dev/production parity as we'll be able to achieve.