### PR TITLE
Added `salt-store` service using adapter pattern for persistence layer

### DIFF
--- a/src/services/salt-store/ISaltStore.ts
+++ b/src/services/salt-store/ISaltStore.ts
@@ -1,0 +1,26 @@
+export interface SaltRecord {
+    salt: string;
+    created_at: Date;
+}
+
+export interface ISaltStore {
+    /**
+     * Get the salt for a given site_uuid
+     * @param key - The site_uuid to get the salt for
+     * @returns The salt for the given site_uuid
+     */
+    get(key: string): Promise<SaltRecord>;
+
+    /**
+     * Get all salts
+     * @returns A record of site_uuid to salt
+     */
+    getAll(): Promise<Record<string, SaltRecord>>;
+
+    /**
+     * Set the salt for a given site_uuid
+     * @param key - The site_uuid to set the salt for
+     * @param salt - The salt to set for the given site_uuid
+     */
+    set(key: string, salt: string): Promise<void>;
+};

--- a/src/services/salt-store/MemorySaltStore.ts
+++ b/src/services/salt-store/MemorySaltStore.ts
@@ -1,0 +1,32 @@
+import type {ISaltStore} from './ISaltStore';
+import {SaltRecord} from '../../types';
+
+export class MemorySaltStore implements ISaltStore {
+    private readonly salts: Record<string, SaltRecord> = {};
+
+    async getAll(): Promise<Record<string, SaltRecord>> {
+        const copy: Record<string, SaltRecord> = {};
+        for (const [key, record] of Object.entries(this.salts)) {
+            copy[key] = {
+                salt: record.salt,
+                created_at: new Date(record.created_at)
+            };
+        }
+        return copy;
+    }
+
+    async set(key: string, salt: string): Promise<void> {
+        this.salts[key] = {salt, created_at: new Date()};
+    }
+
+    async get(key: string): Promise<SaltRecord> {
+        const record = this.salts[key];
+        if (!record) {
+            return record;
+        }
+        return {
+            salt: record.salt,
+            created_at: new Date(record.created_at)
+        };
+    }
+}

--- a/src/services/salt-store/README.md
+++ b/src/services/salt-store/README.md
@@ -1,0 +1,36 @@
+# Salt Store Configuration
+
+The salt store can be configured using environment variables to choose between different storage backends.
+
+## Environment Variables
+
+### SALT_STORE_TYPE
+Determines which salt store implementation to use.
+
+**Options:**
+- `memory` (default) - In-memory storage, data is lost on restart
+- `file` - (not implemented yet) - File-based storage, persists data to disk 
+
+**Example:**
+```bash
+SALT_STORE_TYPE=file
+```
+
+### SALT_STORE_FILE_PATH
+When using `SALT_STORE_TYPE=file`, this specifies the file path for storing salts.
+
+**Default:** `salts.json` in the current working directory
+
+**Example:**
+```bash
+SALT_STORE_FILE_PATH=/app/data/salts.json
+```
+
+## Adding New Salt Store Types
+
+To add new salt store implementations (like Redis or Firestore):
+
+1. Create a new class implementing `ISaltStore`
+2. Add the new type to `SaltStoreType` in `SaltStoreFactory.ts`
+3. Add a case for the new type in the `createSaltStore` function
+4. Update this documentation 

--- a/src/services/salt-store/SaltStoreFactory.ts
+++ b/src/services/salt-store/SaltStoreFactory.ts
@@ -1,0 +1,22 @@
+import type {ISaltStore} from './ISaltStore';
+import {MemorySaltStore} from './MemorySaltStore';
+
+export type SaltStoreType = 'memory' | 'file';
+
+export type SaltStoreConfig = {
+    type: SaltStoreType;
+    filePath?: string;
+};
+
+export function createSaltStore(config?: SaltStoreConfig): ISaltStore {
+    const storeType = config?.type || 'memory';
+
+    switch (storeType) {
+    case 'memory':
+        return new MemorySaltStore();
+    case 'file':
+        throw new Error('File salt store is not implemented yet');
+    default:
+        throw new Error(`Unknown salt store type: ${storeType}`);
+    }
+}

--- a/src/services/salt-store/index.ts
+++ b/src/services/salt-store/index.ts
@@ -1,0 +1,4 @@
+export type {ISaltStore, SaltRecord} from './ISaltStore';
+export {MemorySaltStore} from './MemorySaltStore';
+export {createSaltStore} from './SaltStoreFactory';
+export type {SaltStoreType, SaltStoreConfig} from './SaltStoreFactory';

--- a/test/services/salt-store/MemorySaltStore.test.ts
+++ b/test/services/salt-store/MemorySaltStore.test.ts
@@ -1,0 +1,161 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+import {MemorySaltStore} from '../../../src/services/salt-store/MemorySaltStore';
+
+describe('MemorySaltStore', () => {
+    let saltStore: MemorySaltStore;
+
+    beforeEach(() => {
+        saltStore = new MemorySaltStore();
+    });
+
+    describe('set', () => {
+        it('should store a salt with key', async () => {
+            const key = 'test-site-uuid';
+            const salt = 'random-salt-123';
+
+            await saltStore.set(key, salt);
+
+            const result = await saltStore.get(key);
+            expect(result.salt).toBe(salt);
+            expect(result.created_at).toBeInstanceOf(Date);
+        });
+
+        it('should create a new date for created_at', async () => {
+            const key = 'test-site-uuid';
+            const salt = 'random-salt-123';
+            const beforeSet = new Date();
+
+            await saltStore.set(key, salt);
+
+            const result = await saltStore.get(key);
+            expect(result.created_at.getTime()).toBeGreaterThanOrEqual(beforeSet.getTime());
+        });
+
+        it('should overwrite existing salt', async () => {
+            const key = 'test-site-uuid';
+            const originalSalt = 'original-salt';
+            const newSalt = 'new-salt';
+
+            await saltStore.set(key, originalSalt);
+            await saltStore.set(key, newSalt);
+
+            const result = await saltStore.get(key);
+            expect(result.salt).toBe(newSalt);
+        });
+    });
+
+    describe('get', () => {
+        it('should return salt record for existing key', async () => {
+            const key = 'test-site-uuid';
+            const salt = 'random-salt-123';
+
+            await saltStore.set(key, salt);
+            const result = await saltStore.get(key);
+
+            expect(result).toEqual({
+                salt: salt,
+                created_at: expect.any(Date)
+            });
+        });
+
+        it('should return undefined for non-existent key', async () => {
+            const result = await saltStore.get('non-existent-key');
+            expect(result).toBeUndefined();
+        });
+
+        it('should return a copy of the salt record', async () => {
+            const key = 'test-site-uuid';
+            const salt = 'random-salt-123';
+
+            await saltStore.set(key, salt);
+            const result1 = await saltStore.get(key);
+            const result2 = await saltStore.get(key);
+
+            expect(result1).toEqual(result2);
+            expect(result1).not.toBe(result2);
+            expect(result1.created_at).not.toBe(result2.created_at);
+
+            result1.salt = 'modified';
+            const result3 = await saltStore.get(key);
+            expect(result3.salt).toBe(salt);
+        });
+    });
+
+    describe('getAll', () => {
+        it('should return empty object when no salts are stored', async () => {
+            const result = await saltStore.getAll();
+            expect(result).toEqual({});
+        });
+
+        it('should return all stored salts', async () => {
+            const salt1 = 'salt-1';
+            const salt2 = 'salt-2';
+            const key1 = 'site-uuid-1';
+            const key2 = 'site-uuid-2';
+
+            await saltStore.set(key1, salt1);
+            await saltStore.set(key2, salt2);
+
+            const result = await saltStore.getAll();
+
+            expect(Object.keys(result)).toHaveLength(2);
+            expect(result[key1].salt).toBe(salt1);
+            expect(result[key2].salt).toBe(salt2);
+            expect(result[key1].created_at).toBeInstanceOf(Date);
+            expect(result[key2].created_at).toBeInstanceOf(Date);
+        });
+
+        it('should return a copy of the internal state', async () => {
+            const key = 'test-site-uuid';
+            const salt = 'random-salt-123';
+
+            await saltStore.set(key, salt);
+            const result1 = await saltStore.getAll();
+            const result2 = await saltStore.getAll();
+
+            expect(result1).toEqual(result2);
+            expect(result1).not.toBe(result2);
+
+            result1[key].salt = 'modified';
+            const result3 = await saltStore.getAll();
+            expect(result3[key].salt).toBe(salt);
+        });
+    });
+
+    describe('integration tests', () => {
+        it('should handle multiple operations correctly', async () => {
+            const keys = ['site-1', 'site-2', 'site-3'];
+            const salts = ['salt-1', 'salt-2', 'salt-3'];
+
+            for (let i = 0; i < keys.length; i++) {
+                await saltStore.set(keys[i], salts[i]);
+            }
+
+            const allSalts = await saltStore.getAll();
+            expect(Object.keys(allSalts)).toHaveLength(3);
+
+            for (let i = 0; i < keys.length; i++) {
+                const salt = await saltStore.get(keys[i]);
+                expect(salt.salt).toBe(salts[i]);
+            }
+        });
+
+        it('should maintain isolation between different instances', async () => {
+            const store1 = new MemorySaltStore();
+            const store2 = new MemorySaltStore();
+
+            await store1.set('key1', 'salt1');
+            await store2.set('key2', 'salt2');
+
+            const result1 = await store1.get('key1');
+            const result2 = await store2.get('key2');
+            const missing1 = await store1.get('key2');
+            const missing2 = await store2.get('key1');
+
+            expect(result1.salt).toBe('salt1');
+            expect(result2.salt).toBe('salt2');
+            expect(missing1).toBeUndefined();
+            expect(missing2).toBeUndefined();
+        });
+    });
+});

--- a/test/services/salt-store/SaltStoreFactory.test.ts
+++ b/test/services/salt-store/SaltStoreFactory.test.ts
@@ -1,0 +1,79 @@
+import {describe, it, expect} from 'vitest';
+import {createSaltStore, SaltStoreConfig} from '../../../src/services/salt-store/SaltStoreFactory';
+import {MemorySaltStore} from '../../../src/services/salt-store/MemorySaltStore';
+import type {ISaltStore} from '../../../src/services/salt-store/ISaltStore';
+
+describe('SaltStoreFactory', () => {
+    describe('createSaltStore', () => {
+        it('should create a memory salt store by default', () => {
+            const store = createSaltStore();
+
+            expect(store).toBeInstanceOf(MemorySaltStore);
+            expect(store).toHaveProperty('get');
+            expect(store).toHaveProperty('set');
+            expect(store).toHaveProperty('getAll');
+        });
+
+        it('should create a memory salt store with explicit memory config', () => {
+            const config: SaltStoreConfig = {type: 'memory'};
+            const store = createSaltStore(config);
+
+            expect(store).toBeInstanceOf(MemorySaltStore);
+        });
+
+        it('should throw error for file store type', () => {
+            const config: SaltStoreConfig = {type: 'file'};
+
+            expect(() => createSaltStore(config)).toThrow('File salt store is not implemented yet');
+        });
+
+        it('should throw error for unknown store type', () => {
+            const config = {type: 'unknown' as 'memory'};
+
+            expect(() => createSaltStore(config)).toThrow('Unknown salt store type: unknown');
+        });
+
+        it('should handle undefined config gracefully', () => {
+            const store = createSaltStore(undefined);
+
+            expect(store).toBeInstanceOf(MemorySaltStore);
+        });
+
+        it('should handle empty config object', () => {
+            const config = {} as SaltStoreConfig;
+            const store = createSaltStore(config);
+
+            expect(store).toBeInstanceOf(MemorySaltStore);
+        });
+    });
+
+    describe('returned salt store functionality', () => {
+        it('should return a functional ISaltStore instance', async () => {
+            const store: ISaltStore = createSaltStore();
+
+            await store.set('test-key', 'test-salt');
+            const result = await store.get('test-key');
+
+            expect(result.salt).toBe('test-salt');
+            expect(result.created_at).toBeInstanceOf(Date);
+        });
+
+        it('should create independent store instances', async () => {
+            const store1 = createSaltStore();
+            const store2 = createSaltStore();
+
+            await store1.set('key1', 'salt1');
+            await store2.set('key2', 'salt2');
+
+            const result1 = await store1.get('key1');
+            const result2 = await store2.get('key2');
+            const missing1 = await store1.get('key2');
+            const missing2 = await store2.get('key1');
+
+            expect(result1.salt).toBe('salt1');
+            expect(result2.salt).toBe('salt2');
+            expect(missing1).toBeUndefined();
+            expect(missing2).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
refs https://linear.app/ghost/issue/PROD-662/analytics-service-should-use-salt-hash-instead-of-storing-the-session

We want to start using a salt + hash fingerprinting method to uniquely and anonymously identify "sessions", rather than persisting session IDs client side in the tracker. This commit adds a `salt-store` service for persisting the salt for each site in an arbitrary persistence layer. By default it uses an in-memory store — this won't work in production since it will be wiped on restarts, but it's sufficient for development and prototyping. 

Once we align on our persistence backend layer for Ghost(Pro) and for self-hosters, we can create stores for them and swap them out easily enough.