### PR TITLE
Added typechecking to test files

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -19,7 +19,7 @@ services:
   test:
     image: local/traffic-analytics:development
     pull_policy: never
-    command: ["yarn", "test"]
+    command: sh -c "yarn test && yarn lint"
     volumes:
       - .:/app
       - node_modules_volume:/app/node_modules

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@types/dotenv": "8.2.3",
     "@types/node": "22.15.29",
+    "@types/supertest": "^6.0.3",
     "@types/ua-parser-js": "0.7.39",
     "@vitest/coverage-v8": "3.2.1",
     "eslint": "8.57.1",

--- a/test/.eslintrc.cjs
+++ b/test/.eslintrc.cjs
@@ -2,5 +2,9 @@ module.exports = {
     plugins: ['ghost'],
     extends: [
         'plugin:ghost/ts-test'
-    ]
+    ],
+    rules: {
+        // Using explicit any in tests is fine
+        '@typescript-eslint/no-explicit-any': 'off'
+    }
 };

--- a/test/unit/app.test.ts
+++ b/test/unit/app.test.ts
@@ -29,7 +29,16 @@ type TargetRequest = {
     url: string;
     query: Record<string, string>;
     headers: Record<string, string>;
-    body: Record<string, unknown>;
+    body: {
+        payload: {
+            browser: string;
+            device: string;
+            os: string;
+            meta: {
+                userSignature: string;
+            };
+        };
+    };
 };
 
 // This approach uses the inline server provided by Fastify for testing
@@ -183,7 +192,7 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect((targetRequest.body.payload as any).os).toBe('macos');
+            expect(targetRequest.body.payload.os).toBe('macos');
         });
 
         it('should parse the browser from the user agent and pass it to the upstream server', async function () {
@@ -195,7 +204,7 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect((targetRequest.body.payload as any).browser).toBe('chrome');
+            expect(targetRequest.body.payload.browser).toBe('chrome');
         });
 
         it('should parse the device from the user agent and pass it to the upstream server', async function () {
@@ -207,7 +216,7 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect((targetRequest.body.payload as any).device).toBe('desktop');
+            expect(targetRequest.body.payload.device).toBe('desktop');
         });
 
         it('should generate user signature and pass it to the upstream server', async function () {
@@ -219,9 +228,9 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect((targetRequest.body.payload as any).meta).toBeDefined();
-            expect((targetRequest.body.payload as any).meta.userSignature).toBeDefined();
-            expect((targetRequest.body.payload as any).meta.userSignature).toMatch(/^[a-f0-9]{64}$/); // SHA-256 hex format
+            expect(targetRequest.body.payload.meta).toBeDefined();
+            expect(targetRequest.body.payload.meta.userSignature).toBeDefined();
+            expect(targetRequest.body.payload.meta.userSignature).toMatch(/^[a-f0-9]{64}$/); // SHA-256 hex format
         });
     });
 
@@ -296,7 +305,7 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect((targetRequest.body.payload as any).os).toBe('macos');
+            expect(targetRequest.body.payload.os).toBe('macos');
         });
 
         it('should parse the browser from the user agent and pass it to the upstream server', async function () {
@@ -308,7 +317,7 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect((targetRequest.body.payload as any).browser).toBe('chrome');
+            expect(targetRequest.body.payload.browser).toBe('chrome');
         });
 
         it('should parse the device from the user agent and pass it to the upstream server', async function () {
@@ -320,7 +329,7 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect((targetRequest.body.payload as any).device).toBe('desktop');
+            expect(targetRequest.body.payload.device).toBe('desktop');
         });
     });
 });

--- a/test/unit/app.test.ts
+++ b/test/unit/app.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect, beforeEach, beforeAll, afterAll} from 'vitest';
-import request from 'supertest';
+import request, {Response} from 'supertest';
 import createMockUpstream from '../utils/mock-upstream';
 import {FastifyInstance} from 'fastify';
 import {Server} from 'http';
@@ -117,7 +117,7 @@ describe('Fastify App', () => {
             await request(proxyServer)
                 .post('/tb/web_analytics?name=test')
                 .expect(400)
-                .expect(function (res) {
+                .expect(function (res: Response) {
                     if (!res.body.error || !res.body.message) {
                         throw new Error('Expected error response with message');
                     }
@@ -183,7 +183,7 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect(targetRequest.body.payload.os).toBe('macos');
+            expect((targetRequest.body.payload as any).os).toBe('macos');
         });
 
         it('should parse the browser from the user agent and pass it to the upstream server', async function () {
@@ -195,7 +195,7 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect(targetRequest.body.payload.browser).toBe('chrome');
+            expect((targetRequest.body.payload as any).browser).toBe('chrome');
         });
 
         it('should parse the device from the user agent and pass it to the upstream server', async function () {
@@ -207,7 +207,7 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect(targetRequest.body.payload.device).toBe('desktop');
+            expect((targetRequest.body.payload as any).device).toBe('desktop');
         });
 
         it('should generate user signature and pass it to the upstream server', async function () {
@@ -219,9 +219,9 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect(targetRequest.body.payload.meta).toBeDefined();
-            expect(targetRequest.body.payload.meta.userSignature).toBeDefined();
-            expect(targetRequest.body.payload.meta.userSignature).toMatch(/^[a-f0-9]{64}$/); // SHA-256 hex format
+            expect((targetRequest.body.payload as any).meta).toBeDefined();
+            expect((targetRequest.body.payload as any).meta.userSignature).toBeDefined();
+            expect((targetRequest.body.payload as any).meta.userSignature).toMatch(/^[a-f0-9]{64}$/); // SHA-256 hex format
         });
     });
 
@@ -296,7 +296,7 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect(targetRequest.body.payload.os).toBe('macos');
+            expect((targetRequest.body.payload as any).os).toBe('macos');
         });
 
         it('should parse the browser from the user agent and pass it to the upstream server', async function () {
@@ -308,7 +308,7 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect(targetRequest.body.payload.browser).toBe('chrome');
+            expect((targetRequest.body.payload as any).browser).toBe('chrome');
         });
 
         it('should parse the device from the user agent and pass it to the upstream server', async function () {
@@ -320,7 +320,7 @@ describe('Fastify App', () => {
                 .expect(202);
 
             const targetRequest = targetRequests[0];
-            expect(targetRequest.body.payload.device).toBe('desktop');
+            expect((targetRequest.body.payload as any).device).toBe('desktop');
         });
     });
 });

--- a/test/unit/services/proxy/processors/parse-user-agent.test.ts
+++ b/test/unit/services/proxy/processors/parse-user-agent.test.ts
@@ -12,8 +12,8 @@ describe('Processors', () => {
                     'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36'
                 },
                 body: {
-                    payload: {}
-                },
+                    payload: {} as any
+                } as any,
                 log: {
                     error: () => {},
                     info: () => {}
@@ -34,8 +34,8 @@ describe('Processors', () => {
                     'user-agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1'
                 },
                 body: {
-                    payload: {}
-                },
+                    payload: {} as any
+                } as any,
                 log: {
                     error: () => {},
                     info: () => {}
@@ -52,8 +52,8 @@ describe('Processors', () => {
                     'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36'
                 },
                 body: {
-                    payload: {}
-                },
+                    payload: {} as any
+                } as any,
                 log: {
                     error: () => {},
                     info: () => {}
@@ -70,8 +70,8 @@ describe('Processors', () => {
                     'user-agent': 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
                 },
                 body: {
-                    payload: {}
-                },
+                    payload: {} as any
+                } as any,
                 log: {
                     error: () => {},
                     info: () => {}
@@ -86,8 +86,8 @@ describe('Processors', () => {
             const request: Partial<HttpProxyRequest> = {
                 headers: {},
                 body: {
-                    payload: {}
-                },
+                    payload: {} as any
+                } as any,
                 log: {
                     error: () => {},
                     info: () => {}

--- a/test/unit/services/proxy/processors/url-referrer.test.ts
+++ b/test/unit/services/proxy/processors/url-referrer.test.ts
@@ -52,9 +52,9 @@ describe('Referrer Parser', () => {
     it('should parse referrer data and add it to the payload', () => {
         urlReferrerModule.parseReferrer(request);
 
-        expect(request.body.payload.meta.referrerSource).toBe('Google');
-        expect(request.body.payload.meta.referrerMedium).toBe('search');
-        expect(request.body.payload.meta.referrerUrl).toBe('https://www.google.com/search?q=ghost+cms');
+        expect(request.body.payload.meta?.referrerSource).toBe('Google');
+        expect(request.body.payload.meta?.referrerMedium).toBe('search');
+        expect(request.body.payload.meta?.referrerUrl).toBe('https://www.google.com/search?q=ghost+cms');
         expect(request.body.payload.parsedReferrer).toBeUndefined();
     });
 
@@ -70,7 +70,7 @@ describe('Referrer Parser', () => {
     it('should handle non-object parsedReferrer headers', () => {
         const testRequest = structuredClone(request);
         // Use type assertion to handle the test case
-        testRequest.body.payload.parsedReferrer = 'not-an-object' as unknown as Record<string, unknown>;
+        testRequest.body.payload.parsedReferrer = 'not-an-object' as unknown as { source: string | null; medium: string | null; url: string | null; };
 
         urlReferrerModule.parseReferrer(testRequest);
 
@@ -80,7 +80,7 @@ describe('Referrer Parser', () => {
     it('should handle missing referrer properties', () => {
         const testRequest = structuredClone(request);
         // Use empty object with type assertion
-        testRequest.body.payload.parsedReferrer = {} as Record<string, unknown>;
+        testRequest.body.payload.parsedReferrer = {} as { source: string | null; medium: string | null; url: string | null; };
 
         urlReferrerModule.parseReferrer(testRequest);
 

--- a/test/unit/services/proxy/processors/user-signature.test.ts
+++ b/test/unit/services/proxy/processors/user-signature.test.ts
@@ -75,8 +75,7 @@ describe('User Signature Processor', () => {
     });
 
     it('should skip if site_uuid is not a string', async () => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        request.body.payload.site_uuid = 123 as any;
+        (request.body.payload as any).site_uuid = 123;
 
         await generateUserSignature(request);
 
@@ -85,7 +84,6 @@ describe('User Signature Processor', () => {
     });
 
     it('should skip if IP address is missing', async () => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (request as any).ip = undefined;
 
         await generateUserSignature(request);
@@ -117,8 +115,7 @@ describe('User Signature Processor', () => {
     });
 
     it('should handle missing body gracefully', async () => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        request.body = undefined as any;
+        (request.body as any) = undefined;
 
         await generateUserSignature(request);
 
@@ -126,8 +123,7 @@ describe('User Signature Processor', () => {
     });
 
     it('should handle missing payload gracefully', async () => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        request.body.payload = undefined as any;
+        (request.body as any).payload = undefined;
 
         await generateUserSignature(request);
 

--- a/test/unit/services/proxy/processors/user-signature.test.ts
+++ b/test/unit/services/proxy/processors/user-signature.test.ts
@@ -66,7 +66,7 @@ describe('User Signature Processor', () => {
     });
 
     it('should skip if site_uuid is missing', async () => {
-        delete request.body.payload.site_uuid;
+        (request.body.payload as any).site_uuid = undefined;
 
         await generateUserSignature(request);
 
@@ -86,7 +86,7 @@ describe('User Signature Processor', () => {
 
     it('should skip if IP address is missing', async () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        request.ip = undefined as any;
+        (request as any).ip = undefined;
 
         await generateUserSignature(request);
 

--- a/test/unit/services/user-signature/UserSignatureService.test.ts
+++ b/test/unit/services/user-signature/UserSignatureService.test.ts
@@ -100,7 +100,6 @@ describe('UserSignatureService', () => {
             const mockDate = '2024-01-01T12:00:00.000Z';
             vi.spyOn(Date.prototype, 'toISOString').mockReturnValue(mockDate);
 
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const salt = await (userSignatureService as any).getOrCreateSaltForSite(testSiteUuid);
 
             const signature = await userSignatureService.generateUserSignature(testSiteUuid, testIp, testUserAgent);
@@ -136,9 +135,7 @@ describe('UserSignatureService', () => {
 
     describe('private methods testing via reflection', () => {
         it('should generate random salt of correct length', () => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const salt1 = (userSignatureService as any).generateRandomSalt();
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const salt2 = (userSignatureService as any).generateRandomSalt();
 
             expect(typeof salt1).toBe('string');
@@ -150,14 +147,12 @@ describe('UserSignatureService', () => {
         it('should generate key with date and site UUID', () => {
             vi.spyOn(Date.prototype, 'toISOString').mockReturnValue('2024-01-01T12:00:00.000Z');
 
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const key = (userSignatureService as any).getKey('550e8400-e29b-41d4-a716-446655440000');
 
             expect(key).toBe('salt:2024-01-01:550e8400-e29b-41d4-a716-446655440000');
         });
 
         it('should create and return new salt when salt does not exist', async () => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const result = await (userSignatureService as any).getOrCreateSaltForSite('987fcdeb-51d2-43e1-9b45-123456789abc');
 
             expect(typeof result).toBe('string');
@@ -173,7 +168,6 @@ describe('UserSignatureService', () => {
             const testSalt = 'existing-salt';
             await mockSaltStore.set(expectedKey, testSalt);
 
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const result = await (userSignatureService as any).getOrCreateSaltForSite(existingSiteUuid);
 
             expect(result).toBe(testSalt);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
       "moduleResolution": "bundler",
       "resolveJsonModule": true
     },
-    "include": ["src/**/*", "server.ts"],
-    "exclude": ["node_modules", "**/*.test.ts", "dist"]
+    "include": ["src/**/*", "server.ts", "test/**/*"],
+    "exclude": ["node_modules", "dist"]
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1422,6 +1422,11 @@
   dependencies:
     "@types/deep-eql" "*"
 
+"@types/cookiejar@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.5.tgz#14a3e83fa641beb169a2dd8422d91c3c345a9a78"
+  integrity sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==
+
 "@types/deep-eql@*":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
@@ -1444,12 +1449,17 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
+"@types/methods@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@types/methods/-/methods-1.1.4.tgz#d3b7ac30ac47c91054ea951ce9eed07b1051e547"
+  integrity sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==
+
 "@types/minimatch@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
-"@types/node@22.15.29":
+"@types/node@*", "@types/node@22.15.29":
   version "22.15.29"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.29.tgz#c75999124a8224a3f79dd8b6ccfb37d74098f678"
   integrity sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==
@@ -1465,6 +1475,24 @@
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.7.0.tgz#64c441bdae033b378b6eef7d0c3d77c329b9378e"
   integrity sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==
+
+"@types/superagent@^8.1.0":
+  version "8.1.9"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-8.1.9.tgz#28bfe4658e469838ed0bf66d898354bcab21f49f"
+  integrity sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==
+  dependencies:
+    "@types/cookiejar" "^2.1.5"
+    "@types/methods" "^1.1.4"
+    "@types/node" "*"
+    form-data "^4.0.0"
+
+"@types/supertest@^6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@types/supertest/-/supertest-6.0.3.tgz#d736f0e994b195b63e1c93e80271a2faf927388c"
+  integrity sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==
+  dependencies:
+    "@types/methods" "^1.1.4"
+    "@types/superagent" "^8.1.0"
 
 "@types/symlink-or-copy@^1.2.0":
   version "1.2.2"


### PR DESCRIPTION
no refs

My IDE was flagging a lot of type errors in the tests with red squiggles, but they weren't being checked in the `test:types` command, as the tests were excluded. I hate looking at red squiggles, so this commit enables type checking on the test files, but carves out an exception for explicit `any`, since it is often required in tests (i.e. when testing private methods).