### PR TITLE
Added databaseId parameter to FirestoreSaltStore

### DIFF
--- a/src/services/salt-store/FirestoreSaltStore.ts
+++ b/src/services/salt-store/FirestoreSaltStore.ts
@@ -15,14 +15,18 @@ export class FirestoreSaltStore implements ISaltStore {
      * Creates a new FirestoreSaltStore instance.
      *
      * @param projectId - The Google Cloud project ID
+     * @param databaseId - The Firestore database ID (for named databases)
      * @param collectionName - The name of the Firestore collection to use (default: 'salts')
      */
-    constructor(projectId?: string, collectionName: string = 'salts') {
+    constructor(projectId: string, databaseId: string, collectionName: string = 'salts') {
         // Initialize Firestore client
         // If FIRESTORE_EMULATOR_HOST is set, it will automatically connect to the emulator
-        this.firestore = new Firestore({
-            projectId: projectId || process.env.FIRESTORE_PROJECT_ID || 'traffic-analytics'
-        });
+        const firestoreConfig: {projectId: string; databaseId: string} = {
+            projectId,
+            databaseId
+        };
+        
+        this.firestore = new Firestore(firestoreConfig);
         this.collectionName = collectionName;
         
         // Perform a basic health check to fail fast if Firestore is unavailable

--- a/src/services/salt-store/SaltStoreFactory.ts
+++ b/src/services/salt-store/SaltStoreFactory.ts
@@ -8,6 +8,7 @@ export type SaltStoreConfig = {
     type: SaltStoreType;
     filePath?: string;
     projectId?: string;
+    databaseId?: string;
     collectionName?: string;
 };
 
@@ -17,8 +18,20 @@ export function createSaltStore(config?: SaltStoreConfig): ISaltStore {
     switch (storeType) {
     case 'memory':
         return new MemorySaltStore();
-    case 'firestore':
-        return new FirestoreSaltStore(config?.projectId, config?.collectionName);
+    case 'firestore': {
+        const projectId = config?.projectId || process.env.FIRESTORE_PROJECT_ID;
+        const databaseId = config?.databaseId || process.env.FIRESTORE_DATABASE_ID;
+        
+        if (!projectId) {
+            throw new Error('Firestore project ID is required. Provide it via config.projectId or FIRESTORE_PROJECT_ID environment variable');
+        }
+        
+        if (!databaseId) {
+            throw new Error('Firestore database ID is required. Provide it via config.databaseId or FIRESTORE_DATABASE_ID environment variable');
+        }
+        
+        return new FirestoreSaltStore(projectId, databaseId, config?.collectionName);
+    }
     case 'file':
         throw new Error('File salt store is not implemented yet');
     default:

--- a/test/integration/services/salt-store/FirestoreSaltStore.test.ts
+++ b/test/integration/services/salt-store/FirestoreSaltStore.test.ts
@@ -7,7 +7,8 @@ describe('FirestoreSaltStore', () => {
 
     beforeEach(async () => {
         // Create a new instance for each test
-        saltStore = new FirestoreSaltStore(undefined, testCollectionName);
+        // Using test project and database IDs
+        saltStore = new FirestoreSaltStore('traffic-analytics-test', '(default)', testCollectionName);
 
         // Clean up any existing test data using the store's clear method
         await saltStore.clear();


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-662/analytics-service-should-use-salt-hash-instead-of-storing-the-session

The previous implementation would get the Firestore database based on the GCP project ID, but both our staging and production DBs are in the same project, so this won't work. This change allows you to specify a database ID via environment variable, so we can point the analytics service to the correct database.