### PR TITLE
Fixed the user signature generation

### DIFF
--- a/src/services/user-signature/UserSignatureService.ts
+++ b/src/services/user-signature/UserSignatureService.ts
@@ -65,12 +65,13 @@ export class UserSignatureService {
      *
      * Creates a SHA-256 hash of the combination of:
      * - Daily-rotating salt (specific to the site)
+     * - Site UUID
      * - User's IP address
      * - User agent string
-     * - Current timestamp
      *
      * The resulting hash is non-reversible, ensuring user privacy while still
-     * allowing for unique user identification within analytics.
+     * allowing for unique user identification within analytics. The same user
+     * making multiple requests on the same day will have the same signature.
      *
      * @param siteUuid - The unique identifier of the site
      * @param ipAddress - The user's IP address
@@ -79,8 +80,7 @@ export class UserSignatureService {
      */
     async generateUserSignature(siteUuid: string, ipAddress: string, userAgent: string): Promise<string> {
         const salt = await this.getOrCreateSaltForSite(siteUuid);
-        const timestamp = new Date().toISOString();
-        const signature = `${salt}:${ipAddress}:${userAgent}:${timestamp}`;
+        const signature = `${salt}:${siteUuid}:${ipAddress}:${userAgent}`;
         const hashedSignature = crypto.createHash('sha256').update(signature).digest('hex');
         return hashedSignature;
     }

--- a/test/unit/services/user-signature/UserSignatureService.test.ts
+++ b/test/unit/services/user-signature/UserSignatureService.test.ts
@@ -72,7 +72,7 @@ describe('UserSignatureService', () => {
             expect(typeof signature).toBe('string');
         });
 
-        it('should generate different signatures for different timestamps on same day', async () => {
+        it('should generate same signatures for different timestamps on same day', async () => {
             const timeStub = vi.spyOn(Date.prototype, 'toISOString');
 
             timeStub.mockReturnValue('2024-01-01T12:00:00.000Z');
@@ -81,7 +81,7 @@ describe('UserSignatureService', () => {
             timeStub.mockReturnValue('2024-01-01T12:00:01.000Z');
             const signature2 = await userSignatureService.generateUserSignature(testSiteUuid, testIp, testUserAgent);
 
-            expect(signature1).not.toBe(signature2);
+            expect(signature1).toBe(signature2);
         });
 
         it('should generate different signatures for different days (UTC)', async () => {
@@ -104,7 +104,7 @@ describe('UserSignatureService', () => {
 
             const signature = await userSignatureService.generateUserSignature(testSiteUuid, testIp, testUserAgent);
 
-            const expectedInput = `${salt}:${testIp}:${testUserAgent}:${mockDate}`;
+            const expectedInput = `${salt}:${testSiteUuid}:${testIp}:${testUserAgent}`;
             const expectedHash = crypto.createHash('sha256').update(expectedInput).digest('hex');
             expect(signature).toBe(expectedHash);
         });


### PR DESCRIPTION
no refs

The user signature generation wasn't consistent for multiple requests from the same browser because we were including a timestamp in the signature, which makes it different for each request and defeats the purpose of a user signature. This removes the timestamp, and also adds the `site_uuid` itself to the signature to prevent cross-site tracking. 