### PR TITLE
Added scheduler to cleanup old salts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ The service follows a modular architecture:
 - `PROXY_TARGET` - Upstream URL to forward requests
 - `LOG_LEVEL` - Logging level (default: info)
 - `SALT_STORE_TYPE` - Salt store implementation (default: memory)
+- `ENABLE_SALT_CLEANUP_SCHEDULER` - Enable automatic daily salt cleanup (default: true, set to 'false' to disable)
 
 ## Testing Approach
 

--- a/src/services/salt-store/FirestoreSaltStore.ts
+++ b/src/services/salt-store/FirestoreSaltStore.ts
@@ -216,8 +216,7 @@ export class FirestoreSaltStore implements ISaltStore {
             await batch.commit();
             return snapshot.size;
         } catch (error) {
-            // eslint-disable-next-line no-console
-            console.error('FirestoreSaltStore cleanup failed:', error);
+            logger.error('FirestoreSaltStore cleanup failed:', error);
             throw error;
         }
     }

--- a/src/services/salt-store/FirestoreSaltStore.ts
+++ b/src/services/salt-store/FirestoreSaltStore.ts
@@ -188,4 +188,37 @@ export class FirestoreSaltStore implements ISaltStore {
         
         await batch.commit();
     }
+
+    /**
+     * Delete all salts from before today (UTC)
+     * @returns Number of salts deleted
+     */
+    async cleanup(): Promise<number> {
+        try {
+            // Get today's date in UTC (same logic as UserSignatureService)
+            const today = new Date().toISOString().split('T')[0];
+            const cutoffDate = new Date(today); // This will be midnight UTC of today
+            
+            const snapshot = await this.firestore
+                .collection(this.collectionName)
+                .where('created_at', '<', cutoffDate)
+                .get();
+
+            if (snapshot.size === 0) {
+                return 0;
+            }
+
+            const batch = this.firestore.batch();
+            snapshot.docs.forEach((doc) => {
+                batch.delete(doc.ref);
+            });
+            
+            await batch.commit();
+            return snapshot.size;
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error('FirestoreSaltStore cleanup failed:', error);
+            throw error;
+        }
+    }
 }

--- a/src/services/salt-store/ISaltStore.ts
+++ b/src/services/salt-store/ISaltStore.ts
@@ -36,4 +36,10 @@ export interface ISaltStore {
      * WARNING: This deletes all data! Use with caution, primarily for testing.
      */
     clear(): Promise<void>;
+
+    /**
+     * Delete all salts from days before today (UTC)
+     * @returns Number of salts deleted
+     */
+    cleanup(): Promise<number>;
 };

--- a/src/services/salt-store/MemorySaltStore.ts
+++ b/src/services/salt-store/MemorySaltStore.ts
@@ -42,4 +42,19 @@ export class MemorySaltStore implements ISaltStore {
             delete this.salts[key];
         }
     }
+
+    async cleanup(): Promise<number> {
+        // Get today's date in UTC (same logic as UserSignatureService)
+        const today = new Date().toISOString().split('T')[0];
+        const cutoffDate = new Date(today); // This will be midnight UTC of today
+        
+        let deletedCount = 0;
+        for (const [key, record] of Object.entries(this.salts)) {
+            if (record.created_at < cutoffDate) {
+                delete this.salts[key];
+                deletedCount += 1;
+            }
+        }
+        return deletedCount;
+    }
 }

--- a/src/services/user-signature/UserSignatureService.ts
+++ b/src/services/user-signature/UserSignatureService.ts
@@ -19,7 +19,6 @@ export class UserSignatureService {
      * @param saltStore - The salt store implementation used to persist and retrieve salts
      */
     constructor(saltStore: ISaltStore) {
-        logger.info('UserSignatureService constructor');
         this.saltStore = saltStore;
         this.startCleanupScheduler();
     }

--- a/src/services/user-signature/UserSignatureService.ts
+++ b/src/services/user-signature/UserSignatureService.ts
@@ -1,5 +1,6 @@
 import {ISaltStore} from '../salt-store';
 import crypto from 'crypto';
+import logger from '../../utils/logger';
 
 /**
  * Service for generating privacy-preserving user signatures.
@@ -18,8 +19,7 @@ export class UserSignatureService {
      * @param saltStore - The salt store implementation used to persist and retrieve salts
      */
     constructor(saltStore: ISaltStore) {
-        // eslint-disable-next-line no-console
-        console.log('UserSignatureService constructor');
+        logger.info('UserSignatureService constructor');
         this.saltStore = saltStore;
         this.startCleanupScheduler();
     }
@@ -38,11 +38,9 @@ export class UserSignatureService {
         const runCleanup = async () => {
             try {
                 const deletedCount = await this.saltStore.cleanup();
-                // eslint-disable-next-line no-console
-                console.log(`Salt cleanup completed: ${deletedCount} old salts deleted`);
+                logger.info(`Salt cleanup completed: ${deletedCount} old salts deleted`);
             } catch (error) {
-                // eslint-disable-next-line no-console
-                console.error('Salt cleanup failed:', error);
+                logger.error('Salt cleanup failed:', error);
             }
         };
         
@@ -50,8 +48,7 @@ export class UserSignatureService {
         const randomDelayMinutes = Math.floor(Math.random() * 60);
         const randomDelayMs = randomDelayMinutes * 60 * 1000;
         
-        // eslint-disable-next-line no-console
-        console.log(`Salt cleanup scheduler will start in ${randomDelayMinutes} minutes`);
+        logger.info(`Salt cleanup scheduler will start in ${randomDelayMinutes} minutes`);
         
         // Schedule first cleanup with random delay
         setTimeout(async () => {

--- a/src/services/user-signature/UserSignatureService.ts
+++ b/src/services/user-signature/UserSignatureService.ts
@@ -10,6 +10,7 @@ import crypto from 'crypto';
  */
 export class UserSignatureService {
     private saltStore: ISaltStore;
+    private cleanupInterval: NodeJS.Timeout | null = null;
 
     /**
      * Creates a new UserSignatureService instance.
@@ -17,7 +18,58 @@ export class UserSignatureService {
      * @param saltStore - The salt store implementation used to persist and retrieve salts
      */
     constructor(saltStore: ISaltStore) {
+        // eslint-disable-next-line no-console
+        console.log('UserSignatureService constructor');
         this.saltStore = saltStore;
+        this.startCleanupScheduler();
+    }
+
+    /**
+     * Start the salt cleanup scheduler
+     */
+    private startCleanupScheduler() {
+        // Only start scheduler in production (not during testing)
+        if (process.env.NODE_ENV === 'testing' || process.env.ENABLE_SALT_CLEANUP_SCHEDULER === 'false') {
+            return;
+        }
+
+        const CLEANUP_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+        
+        const runCleanup = async () => {
+            try {
+                const deletedCount = await this.saltStore.cleanup();
+                // eslint-disable-next-line no-console
+                console.log(`Salt cleanup completed: ${deletedCount} old salts deleted`);
+            } catch (error) {
+                // eslint-disable-next-line no-console
+                console.error('Salt cleanup failed:', error);
+            }
+        };
+        
+        // Add random delay (0-60 minutes) to prevent multiple instances from running simultaneously
+        const randomDelayMinutes = Math.floor(Math.random() * 60);
+        const randomDelayMs = randomDelayMinutes * 60 * 1000;
+        
+        // eslint-disable-next-line no-console
+        console.log(`Salt cleanup scheduler will start in ${randomDelayMinutes} minutes`);
+        
+        // Schedule first cleanup with random delay
+        setTimeout(async () => {
+            await runCleanup();
+            
+            // Schedule subsequent cleanups every 24 hours
+            this.cleanupInterval = setInterval(runCleanup, CLEANUP_INTERVAL);
+        }, randomDelayMs);
+    }
+
+    /**
+     * Stop the salt cleanup scheduler (useful for testing or graceful shutdown)
+     */
+    public stopCleanupScheduler() {
+        if (this.cleanupInterval) {
+            clearInterval(this.cleanupInterval);
+            this.cleanupInterval = null;
+        }
     }
 
     /**

--- a/test/integration/services/salt-store/FirestoreSaltStore.test.ts
+++ b/test/integration/services/salt-store/FirestoreSaltStore.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import {FirestoreSaltStore} from '../../../../src/services/salt-store/FirestoreSaltStore';
 
 describe('FirestoreSaltStore', () => {
@@ -118,6 +118,81 @@ describe('FirestoreSaltStore', () => {
                 expect(retrievedSalt).toBeDefined();
                 expect(retrievedSalt!.salt).toBe(newSalt);
             }
+        });
+    });
+
+    describe('cleanup', () => {
+        it('should delete salts from before today UTC', async () => {
+            const key1 = 'salt:2024-01-14:cleanup-test-1';
+            const key2 = 'salt:2024-01-15:cleanup-test-2';
+            const key3 = 'salt:2024-01-10:cleanup-test-3';
+
+            await saltStore.set(key1, 'yesterday-salt');
+            await saltStore.set(key2, 'today-salt');
+            await saltStore.set(key3, 'old-salt');
+
+            // Mock today as 2024-01-15
+            vi.spyOn(Date.prototype, 'toISOString').mockReturnValue('2024-01-15T12:00:00.000Z');
+
+            // Update timestamps
+            const firestore = (saltStore as any).firestore;
+            const batch = firestore.batch();
+            
+            batch.update(firestore.collection(testCollectionName).doc(key1), { 
+                created_at: new Date('2024-01-14T23:59:59.999Z') 
+            });
+            batch.update(firestore.collection(testCollectionName).doc(key2), { 
+                created_at: new Date('2024-01-15T00:00:00.000Z') 
+            });
+            batch.update(firestore.collection(testCollectionName).doc(key3), { 
+                created_at: new Date('2024-01-10T12:00:00.000Z') 
+            });
+            
+            await batch.commit();
+
+            const deletedCount = await saltStore.cleanup();
+
+            expect(deletedCount).toBe(2);
+
+            const result1 = await saltStore.get(key1);
+            const result2 = await saltStore.get(key2);
+            const result3 = await saltStore.get(key3);
+
+            expect(result1).toBeUndefined();
+            expect(result2?.salt).toBe('today-salt');
+            expect(result3).toBeUndefined();
+        });
+
+        it('should keep salts created at exactly midnight UTC today', async () => {
+            const key = 'salt:2024-01-15:midnight-test';
+            await saltStore.set(key, 'midnight-salt');
+
+            // Mock today as 2024-01-15
+            vi.spyOn(Date.prototype, 'toISOString').mockReturnValue('2024-01-15T12:00:00.000Z');
+
+            const firestore = (saltStore as any).firestore;
+            await firestore.collection(testCollectionName).doc(key).update({ 
+                created_at: new Date('2024-01-15T00:00:00.000Z') 
+            });
+
+            const deletedCount = await saltStore.cleanup();
+
+            expect(deletedCount).toBe(0);
+
+            const result = await saltStore.get(key);
+            expect(result?.salt).toBe('midnight-salt');
+        });
+
+        it('should return 0 when all salts are from today', async () => {
+            await saltStore.set('salt:cleanup:today-1', 'salt1');
+            await saltStore.set('salt:cleanup:today-2', 'salt2');
+
+            const deletedCount = await saltStore.cleanup();
+
+            expect(deletedCount).toBe(0);
+
+            const all = await saltStore.getAll();
+            expect(Object.keys(all)).toHaveLength(2);
         });
     });
 });

--- a/test/unit/services/user-signature/UserSignatureService.test.ts
+++ b/test/unit/services/user-signature/UserSignatureService.test.ts
@@ -3,15 +3,16 @@ import {UserSignatureService} from '../../../../src/services/user-signature';
 import {MemorySaltStore} from '../../../../src/services/salt-store/MemorySaltStore';
 import type {ISaltStore} from '../../../../src/services/salt-store';
 import crypto from 'crypto';
+import logger from '../../../../src/utils/logger';
 
 describe('UserSignatureService', () => {
     let userSignatureService: UserSignatureService;
     let mockSaltStore: ISaltStore;
 
     beforeEach(() => {
-        // Mock console methods to avoid noise in tests
-        vi.spyOn(console, 'log').mockImplementation(() => {});
-        vi.spyOn(console, 'error').mockImplementation(() => {});
+        // Mock logger methods to avoid noise in tests
+        vi.spyOn(logger, 'info').mockImplementation(() => {});
+        vi.spyOn(logger, 'error').mockImplementation(() => {});
         
         mockSaltStore = new MemorySaltStore();
         userSignatureService = new UserSignatureService(mockSaltStore);
@@ -279,7 +280,7 @@ describe('UserSignatureService', () => {
                 // Set up spies before creating service
                 const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
                 const cleanupSpy = vi.spyOn(mockSaltStore, 'cleanup').mockResolvedValue(5);
-                const consoleLogSpy = vi.spyOn(console, 'log');
+                const loggerInfoSpy = vi.spyOn(logger, 'info');
                 
                 // Create service - this will call setTimeout
                 const service = new UserSignatureService(mockSaltStore);
@@ -293,7 +294,7 @@ describe('UserSignatureService', () => {
                 await timeoutCallback();
                 
                 expect(cleanupSpy).toHaveBeenCalledOnce();
-                expect(consoleLogSpy).toHaveBeenCalledWith('Salt cleanup completed: 5 old salts deleted');
+                expect(loggerInfoSpy).toHaveBeenCalledWith('Salt cleanup completed: 5 old salts deleted');
                 
                 service.stopCleanupScheduler();
                 process.env.NODE_ENV = originalNodeEnv;
@@ -307,7 +308,7 @@ describe('UserSignatureService', () => {
                 const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
                 const error = new Error('Cleanup failed');
                 const cleanupSpy = vi.spyOn(mockSaltStore, 'cleanup').mockRejectedValue(error);
-                const consoleErrorSpy = vi.spyOn(console, 'error');
+                const loggerErrorSpy = vi.spyOn(logger, 'error');
                 
                 const service = new UserSignatureService(mockSaltStore);
                 
@@ -317,7 +318,7 @@ describe('UserSignatureService', () => {
                 await timeoutCallback();
                 
                 expect(cleanupSpy).toHaveBeenCalledOnce();
-                expect(consoleErrorSpy).toHaveBeenCalledWith('Salt cleanup failed:', error);
+                expect(loggerErrorSpy).toHaveBeenCalledWith('Salt cleanup failed:', error);
                 
                 service.stopCleanupScheduler();
                 process.env.NODE_ENV = originalNodeEnv;

--- a/test/unit/services/user-signature/UserSignatureService.test.ts
+++ b/test/unit/services/user-signature/UserSignatureService.test.ts
@@ -123,7 +123,8 @@ describe('UserSignatureService', () => {
                     return {};
                 },
                 async delete() {},
-                clear: () => Promise.resolve()
+                clear: () => Promise.resolve(),
+                cleanup: () => Promise.resolve(0)
             };
 
             const service = new UserSignatureService(customSaltStore);

--- a/test/unit/services/user-signature/UserSignatureService.test.ts
+++ b/test/unit/services/user-signature/UserSignatureService.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, beforeEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach, vi, afterEach} from 'vitest';
 import {UserSignatureService} from '../../../../src/services/user-signature';
 import {MemorySaltStore} from '../../../../src/services/salt-store/MemorySaltStore';
 import type {ISaltStore} from '../../../../src/services/salt-store';
@@ -9,8 +9,19 @@ describe('UserSignatureService', () => {
     let mockSaltStore: ISaltStore;
 
     beforeEach(() => {
+        // Mock console methods to avoid noise in tests
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        
         mockSaltStore = new MemorySaltStore();
         userSignatureService = new UserSignatureService(mockSaltStore);
+    });
+
+    afterEach(() => {
+        // Clean up any running schedulers
+        userSignatureService.stopCleanupScheduler();
+        vi.restoreAllMocks();
+        vi.clearAllTimers();
     });
 
     describe('constructor', () => {
@@ -173,6 +184,199 @@ describe('UserSignatureService', () => {
             const result = await (userSignatureService as any).getOrCreateSaltForSite(existingSiteUuid);
 
             expect(result).toBe(testSalt);
+        });
+    });
+
+    describe('cleanup scheduler', () => {
+        describe('environment variable controls', () => {
+            it('should not start scheduler when NODE_ENV is testing', () => {
+                const originalEnv = process.env.NODE_ENV;
+                process.env.NODE_ENV = 'testing';
+                
+                const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+                const service = new UserSignatureService(mockSaltStore);
+                
+                expect(setTimeoutSpy).not.toHaveBeenCalled();
+                
+                service.stopCleanupScheduler();
+                process.env.NODE_ENV = originalEnv;
+            });
+
+            it('should not start scheduler when ENABLE_SALT_CLEANUP_SCHEDULER is false', () => {
+                const originalEnv = process.env.ENABLE_SALT_CLEANUP_SCHEDULER;
+                const originalNodeEnv = process.env.NODE_ENV;
+                process.env.ENABLE_SALT_CLEANUP_SCHEDULER = 'false';
+                process.env.NODE_ENV = 'production';
+                
+                const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+                const service = new UserSignatureService(mockSaltStore);
+                
+                expect(setTimeoutSpy).not.toHaveBeenCalled();
+                
+                service.stopCleanupScheduler();
+                process.env.ENABLE_SALT_CLEANUP_SCHEDULER = originalEnv;
+                process.env.NODE_ENV = originalNodeEnv;
+            });
+
+            it('should start scheduler when environment allows', () => {
+                const originalEnv = process.env.ENABLE_SALT_CLEANUP_SCHEDULER;
+                const originalNodeEnv = process.env.NODE_ENV;
+                process.env.ENABLE_SALT_CLEANUP_SCHEDULER = 'true';
+                process.env.NODE_ENV = 'production';
+                
+                const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+                const service = new UserSignatureService(mockSaltStore);
+                
+                expect(setTimeoutSpy).toHaveBeenCalledOnce();
+                expect(setTimeoutSpy).toHaveBeenCalledWith(
+                    expect.any(Function),
+                    expect.any(Number) // Random delay between 0-60 minutes
+                );
+                
+                const delayMs = setTimeoutSpy.mock.calls[0][1] as number;
+                expect(delayMs).toBeGreaterThanOrEqual(0);
+                expect(delayMs).toBeLessThan(60 * 60 * 1000); // Less than 60 minutes
+                
+                service.stopCleanupScheduler();
+                process.env.ENABLE_SALT_CLEANUP_SCHEDULER = originalEnv;
+                process.env.NODE_ENV = originalNodeEnv;
+            });
+        });
+
+        describe('scheduler lifecycle', () => {
+            it('should stop cleanup scheduler', () => {
+                const originalNodeEnv = process.env.NODE_ENV;
+                process.env.NODE_ENV = 'production';
+                
+                const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+                const service = new UserSignatureService(mockSaltStore);
+                
+                // Simulate that the interval was set
+                (service as any).cleanupInterval = 123;
+                
+                service.stopCleanupScheduler();
+                
+                expect(clearIntervalSpy).toHaveBeenCalledWith(123);
+                expect((service as any).cleanupInterval).toBeNull();
+                
+                process.env.NODE_ENV = originalNodeEnv;
+            });
+
+            it('should handle stopping scheduler when no interval is set', () => {
+                const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+                
+                userSignatureService.stopCleanupScheduler();
+                
+                expect(clearIntervalSpy).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('cleanup execution', () => {
+            it('should execute cleanup and log success', async () => {
+                const originalNodeEnv = process.env.NODE_ENV;
+                process.env.NODE_ENV = 'production';
+                
+                // Set up spies before creating service
+                const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+                const cleanupSpy = vi.spyOn(mockSaltStore, 'cleanup').mockResolvedValue(5);
+                const consoleLogSpy = vi.spyOn(console, 'log');
+                
+                // Create service - this will call setTimeout
+                const service = new UserSignatureService(mockSaltStore);
+                
+                expect(setTimeoutSpy).toHaveBeenCalledOnce();
+                
+                // Get the cleanup function from setTimeout call
+                const timeoutCallback = setTimeoutSpy.mock.calls[0][0] as () => Promise<void>;
+                
+                // Execute the cleanup
+                await timeoutCallback();
+                
+                expect(cleanupSpy).toHaveBeenCalledOnce();
+                expect(consoleLogSpy).toHaveBeenCalledWith('Salt cleanup completed: 5 old salts deleted');
+                
+                service.stopCleanupScheduler();
+                process.env.NODE_ENV = originalNodeEnv;
+            });
+
+            it('should handle cleanup errors gracefully', async () => {
+                const originalNodeEnv = process.env.NODE_ENV;
+                process.env.NODE_ENV = 'production';
+                
+                // Set up spies before creating service
+                const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+                const error = new Error('Cleanup failed');
+                const cleanupSpy = vi.spyOn(mockSaltStore, 'cleanup').mockRejectedValue(error);
+                const consoleErrorSpy = vi.spyOn(console, 'error');
+                
+                const service = new UserSignatureService(mockSaltStore);
+                
+                // Get and execute the cleanup function
+                const timeoutCallback = setTimeoutSpy.mock.calls[0][0] as () => Promise<void>;
+                
+                await timeoutCallback();
+                
+                expect(cleanupSpy).toHaveBeenCalledOnce();
+                expect(consoleErrorSpy).toHaveBeenCalledWith('Salt cleanup failed:', error);
+                
+                service.stopCleanupScheduler();
+                process.env.NODE_ENV = originalNodeEnv;
+            });
+
+            it('should set up recurring cleanup after initial run', async () => {
+                const originalNodeEnv = process.env.NODE_ENV;
+                process.env.NODE_ENV = 'production';
+                
+                // Set up spies before creating service
+                const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+                const setIntervalSpy = vi.spyOn(global, 'setInterval');
+                vi.spyOn(mockSaltStore, 'cleanup').mockResolvedValue(0);
+                
+                const service = new UserSignatureService(mockSaltStore);
+                
+                // Get and execute the initial cleanup function
+                const timeoutCallback = setTimeoutSpy.mock.calls[0][0] as () => Promise<void>;
+                
+                await timeoutCallback();
+                
+                // Should set up recurring cleanup
+                expect(setIntervalSpy).toHaveBeenCalledOnce();
+                expect(setIntervalSpy).toHaveBeenCalledWith(
+                    expect.any(Function),
+                    24 * 60 * 60 * 1000 // 24 hours
+                );
+                
+                service.stopCleanupScheduler();
+                process.env.NODE_ENV = originalNodeEnv;
+            });
+        });
+
+        describe('random delay', () => {
+            it('should use different random delays for multiple instances', () => {
+                const originalNodeEnv = process.env.NODE_ENV;
+                process.env.NODE_ENV = 'production';
+                
+                const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+                
+                // Create multiple services
+                const service1 = new UserSignatureService(new MemorySaltStore());
+                const service2 = new UserSignatureService(new MemorySaltStore());
+                
+                expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+                
+                const delay1 = setTimeoutSpy.mock.calls[0][1] as number;
+                const delay2 = setTimeoutSpy.mock.calls[1][1] as number;
+                
+                // Both delays should be in valid range
+                expect(delay1).toBeGreaterThanOrEqual(0);
+                expect(delay1).toBeLessThan(60 * 60 * 1000);
+                expect(delay2).toBeGreaterThanOrEqual(0);
+                expect(delay2).toBeLessThan(60 * 60 * 1000);
+                
+                service1.stopCleanupScheduler();
+                service2.stopCleanupScheduler();
+                process.env.NODE_ENV = originalNodeEnv;
+            });
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-662/analytics-service-should-use-salt-hash-instead-of-storing-the-session

The user generator service recycles salts every 24 hours, but we currently leave the old salts in the store. This commit adds a simpler scheduler to delete any salts from before the current day UTC.

This can be disabled via config, and probably should be handled more robustly at scale, but this works in development and should be fine for self-hosters, since compose itself doesn't have a native scheduler.