### PR TITLE
Fixed firestore container slow shutdown

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -3,9 +3,11 @@ name: traffic-analytics
 services:
   firestore:
     image: google/cloud-sdk:emulators
-    command: ["gcloud", "emulators", "firestore", "start", "--host-port=0.0.0.0:8080"]
+    command: ["/app/firestore-wrapper.sh"]
     ports:
       - 8080:8080
+    volumes:
+      - ./docker/firestore/firestore-wrapper.sh:/app/firestore-wrapper.sh:ro
     environment:
       - FIRESTORE_PROJECT_ID=traffic-analytics-dev
     healthcheck:
@@ -13,6 +15,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    stop_grace_period: 5s
 
   analytics-service:
     image: local/traffic-analytics:development

--- a/docker/firestore/firestore-wrapper.sh
+++ b/docker/firestore/firestore-wrapper.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Signal handler for graceful shutdown
+shutdown() {
+    echo "Received shutdown signal, stopping Firestore emulator..."
+    if [ ! -z "$FIRESTORE_PID" ]; then
+        kill -TERM "$FIRESTORE_PID"
+        wait "$FIRESTORE_PID"
+    fi
+    exit 0
+}
+
+# Set up signal trap
+trap shutdown SIGTERM SIGINT
+
+# Start Firestore emulator in background
+gcloud emulators firestore start --host-port=0.0.0.0:8080 &
+FIRESTORE_PID=$!
+
+# Wait for the background process
+wait "$FIRESTORE_PID"

--- a/src/services/salt-store/FirestoreSaltStore.ts
+++ b/src/services/salt-store/FirestoreSaltStore.ts
@@ -188,4 +188,12 @@ export class FirestoreSaltStore implements ISaltStore {
         
         await batch.commit();
     }
+
+    /**
+     * Closes the Firestore client connection.
+     * Call this during graceful shutdown to immediately close the connection.
+     */
+    async close(): Promise<void> {
+        await this.firestore.terminate();
+    }
 }


### PR DESCRIPTION
no refs

When stopping the compose setup with ctrl+c, the firestore container was using the full 10 second grace period before shutting down, which is annoying. This wraps the command with some basic signal handling so it shuts down immediately.