### PR TITLE
Removed unused method on FirestoreSaltStore

### DIFF
--- a/src/services/salt-store/FirestoreSaltStore.ts
+++ b/src/services/salt-store/FirestoreSaltStore.ts
@@ -188,12 +188,4 @@ export class FirestoreSaltStore implements ISaltStore {
         
         await batch.commit();
     }
-
-    /**
-     * Closes the Firestore client connection.
-     * Call this during graceful shutdown to immediately close the connection.
-     */
-    async close(): Promise<void> {
-        await this.firestore.terminate();
-    }
 }


### PR DESCRIPTION
no refs

This function isn't used anywhere, just taking up space, so this commit removes it.