### PR TITLE
Improved logs in production

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -21,7 +21,6 @@ export function getLoggerConfig(): LoggerOptions | false {
                     return {
                         method: request.method,
                         url: request.url,
-                        path: request.routerPath,
                         params: request.params,
                         query: request.query,
                         headers: {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -21,15 +21,27 @@ export function getLoggerConfig(): LoggerOptions | false {
                     return {
                         method: request.method,
                         url: request.url,
-                        headers: request.headers,
+                        path: request.routerPath,
+                        params: request.params,
+                        query: request.query,
+                        headers: {
+                            host: request.headers.host,
+                            'user-agent': request.headers['user-agent'],
+                            'content-type': request.headers['content-type'],
+                            'content-length': request.headers['content-length'],
+                            referer: request.headers.referer,
+                            'x-forwarded-for': request.headers['x-forwarded-for']
+                        },
                         hostname: request.hostname,
                         remoteAddress: request.ip,
-                        remotePort: request.socket?.remotePort
+                        remotePort: request.socket?.remotePort,
+                        id: request.id
                     };
                 },
                 res(reply: FastifyReply) {
                     return {
-                        statusCode: reply.statusCode
+                        statusCode: reply.statusCode,
+                        headers: reply.getHeaders()
                     };
                 }
             }


### PR DESCRIPTION
no refs

This commit adds more details to the logs in production. Previously the fields included were very limited, to keep the development logs simple, however this inadvertently also limited the production logs so basic things like request method and headers weren't being included — now they are.