### PR TITLE
Updated msg -> message in logs so GCP parses them better

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -16,6 +16,7 @@ export function getLoggerConfig(): LoggerOptions | false {
     if (process.env.NODE_ENV === 'production') {
         return {
             level: process.env.LOG_LEVEL || 'info',
+            messageKey: 'message',
             formatters: {
                 level: (label) => {
                     return {


### PR DESCRIPTION
no refs

GCP will parse out the `message` field from our logs automatically, but the message was being logged as `msg`, which GCP ignores. This changes the message key for pino to use `message` instead of `msg`.