### PR TITLE
Added trace context to logs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -48,6 +48,17 @@ app.register(fastifyCors, {
 });
 
 app.addHook('onRequest', (request, _reply, done) => {
+    const PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT;
+    const traceHeader = request.headers['x-cloud-trace-context'] as string;
+    if (traceHeader && PROJECT_ID) {
+        const traceId = traceHeader.split('/')[0];
+        const traceContext = {
+            'logging.googleapis.com/trace': `projects/${PROJECT_ID}/traces/${traceId}`
+        };
+
+        request.log = request.log.child(traceContext);
+    }
+
     request.log.info({
         httpRequest: {
             requestMethod: request.method,


### PR DESCRIPTION
no refs

This is an attempt to correlate all the logs for a particular request together in GCP. GCP passes a header in all requests with a trace ID, and supposedly if we include it in the logs, it will collapse all the logs from a single request into the top level Cloud Run request log.