### PR TITLE
Improved error handling in user signature service

### DIFF
--- a/src/services/proxy/processors/user-signature.ts
+++ b/src/services/proxy/processors/user-signature.ts
@@ -7,23 +7,25 @@ import {userSignatureService} from '../../user-signature';
  * Extracts the site UUID from the request payload, IP address from the request,
  * and user agent from headers to generate a privacy-preserving user signature.
  * The signature is added to the request payload as meta.userSignature.
+ * 
+ * Throws an error if site_uuid or IP address is missing/invalid.
  *
  * @param request - The Fastify request object
+ * @throws {Error} When site_uuid is missing or not a string
+ * @throws {Error} When IP address is missing
  */
 export async function generateUserSignature(request: FastifyRequest): Promise<void> {
     try {
         // Extract site UUID from payload
         const siteUuid = request.body?.payload?.site_uuid;
         if (!siteUuid || typeof siteUuid !== 'string') {
-            // Skip if no valid site UUID
-            return;
+            throw new Error('Bad Request: site_uuid is required and must be a string');
         }
 
         // Extract IP address from request
         const ipAddress = request.ip;
         if (!ipAddress) {
-            // Skip if no IP address
-            return;
+            throw new Error('Bad Request: IP address is required');
         }
 
         // Extract user agent from headers
@@ -44,7 +46,8 @@ export async function generateUserSignature(request: FastifyRequest): Promise<vo
         // Add user signature to payload
         request.body.payload.meta.userSignature = userSignature;
     } catch (error) {
-        // Log error but don't fail the request
+        // Log error and re-throw to fail the request
         request.log.error('Failed to generate user signature:', error);
+        throw error;
     }
 }

--- a/test/unit/services/proxy/processors/user-signature.test.ts
+++ b/test/unit/services/proxy/processors/user-signature.test.ts
@@ -65,31 +65,28 @@ describe('User Signature Processor', () => {
         });
     });
 
-    it('should skip if site_uuid is missing', async () => {
+    it('should throw error if site_uuid is missing', async () => {
         (request.body.payload as any).site_uuid = undefined;
 
-        await generateUserSignature(request);
+        await expect(generateUserSignature(request)).rejects.toThrow('Bad Request: site_uuid is required and must be a string');
 
         expect(userSignatureService.generateUserSignature).not.toHaveBeenCalled();
-        expect(request.body.payload.meta).toBeUndefined();
     });
 
-    it('should skip if site_uuid is not a string', async () => {
+    it('should throw error if site_uuid is not a string', async () => {
         (request.body.payload as any).site_uuid = 123;
 
-        await generateUserSignature(request);
+        await expect(generateUserSignature(request)).rejects.toThrow('Bad Request: site_uuid is required and must be a string');
 
         expect(userSignatureService.generateUserSignature).not.toHaveBeenCalled();
-        expect(request.body.payload.meta).toBeUndefined();
     });
 
-    it('should skip if IP address is missing', async () => {
+    it('should throw error if IP address is missing', async () => {
         (request as any).ip = undefined;
 
-        await generateUserSignature(request);
+        await expect(generateUserSignature(request)).rejects.toThrow('Bad Request: IP address is required');
 
         expect(userSignatureService.generateUserSignature).not.toHaveBeenCalled();
-        expect(request.body.payload.meta).toBeUndefined();
     });
 
     it('should use empty string if user agent is missing', async () => {
@@ -104,28 +101,27 @@ describe('User Signature Processor', () => {
         );
     });
 
-    it('should handle errors gracefully', async () => {
+    it('should log and re-throw errors from userSignatureService', async () => {
         const error = new Error('Test error');
         vi.mocked(userSignatureService.generateUserSignature).mockRejectedValue(error);
 
-        await generateUserSignature(request);
+        await expect(generateUserSignature(request)).rejects.toThrow('Test error');
 
         expect(request.log.error).toHaveBeenCalledWith('Failed to generate user signature:', error);
-        expect(request.body.payload.meta).toBeUndefined();
     });
 
-    it('should handle missing body gracefully', async () => {
+    it('should throw error if body is missing', async () => {
         (request.body as any) = undefined;
 
-        await generateUserSignature(request);
+        await expect(generateUserSignature(request)).rejects.toThrow('Bad Request: site_uuid is required and must be a string');
 
         expect(userSignatureService.generateUserSignature).not.toHaveBeenCalled();
     });
 
-    it('should handle missing payload gracefully', async () => {
+    it('should throw error if payload is missing', async () => {
         (request.body as any).payload = undefined;
 
-        await generateUserSignature(request);
+        await expect(generateUserSignature(request)).rejects.toThrow('Bad Request: site_uuid is required and must be a string');
 
         expect(userSignatureService.generateUserSignature).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
no refs

The user signature service was just skipping the signature generation if the site_uuid or ip address were missing. This is incorrect — it should throw an error to prevent sending events to Tinybird without a session id. 