### PR TITLE
Added scratch directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ dist*
 
 # Traffic Analytics Custom
 .actsecrets
+
+scratch/


### PR DESCRIPTION
no refs

The intent here is to create a directory for planning work in markdown files, either solo or with an AI agent, which don't get committed to the repo.