### PR TITLE
Added multi-worktree Docker Compose support for parallel development

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,56 @@ SALT_STORE_TYPE=memory  # Options: memory, firestore
 
 # Firestore Configuration (when SALT_STORE_TYPE=firestore)
 FIRESTORE_PROJECT_ID=traffic-analytics-dev
+
+# Multi-worktree Configuration (optional)
+COMPOSE_PROJECT_NAME=traffic-analytics-main  # Default project name
+ANALYTICS_PORT=3000                           # Analytics service port (default: 3000)  
+FIRESTORE_PORT=8080                          # Firestore emulator port (default: 8080)
+```
+
+## Multi-Worktree Development
+
+This project supports running multiple worktrees simultaneously using Docker Compose. Each worktree can run its own isolated development environment with unique ports and container names.
+
+### Setup
+
+1. **Create worktrees** as usual with git worktree
+2. **Configure each worktree** with a unique `.env` file:
+
+```bash
+# main worktree (.env) - uses defaults
+NODE_ENV=development
+
+# work worktree (.env)  
+NODE_ENV=development
+COMPOSE_PROJECT_NAME=traffic-analytics-work
+ANALYTICS_PORT=3001
+FIRESTORE_PORT=8081
+
+# scratch worktree (.env)
+NODE_ENV=development  
+COMPOSE_PROJECT_NAME=traffic-analytics-scratch
+ANALYTICS_PORT=3002
+FIRESTORE_PORT=8082
+```
+
+### Usage
+
+Each worktree runs completely isolated:
+- **Unique ports**: No conflicts between worktrees
+- **Isolated containers**: Auto-generated names like `traffic-analytics-work-analytics-service-1`
+- **Separate volumes**: Each worktree has its own `node_modules` volume
+- **Independent projects**: Services can run simultaneously
+
+```bash
+# Start development in any worktree
+cd /path/to/worktree
+docker compose up
+
+# Each worktree accessible on its configured port
+# main: http://localhost:3000
+# work: http://localhost:3001  
+# scratch: http://localhost:3002
 ```
 
 ## Develop

--- a/README.md
+++ b/README.md
@@ -27,6 +27,39 @@ ANALYTICS_PORT=3000                           # Analytics service port (default:
 FIRESTORE_PORT=8080                          # Firestore emulator port (default: 8080)
 ```
 
+## Develop
+
+1. `git clone` this repo & `cd` into it as usual
+2. Run `yarn` to install top-level dependencies.
+
+## Build
+- `yarn build` to transpile Typescript to JS
+- `docker compose build` or `yarn docker:build` to build docker image
+
+## Run
+
+- `yarn dev` start development server locally
+- `docker compose up` or `yarn docker:dev` start development server in docker compose (includes Firestore emulator)
+- View: [http://localhost:3000](http://localhost:3000)
+
+## Run locally with Ghost in Docker
+
+Sometimes it's useful to test the full setup with Ghost pointing its tracker script to this analytics service running locally. This can be acheived relatively easily with Docker Compose:
+- Set the `tinybird:tracker:endpoint` to `http://localhost/.ghost/analytics/tb/web_analytics` in your Ghost config
+- Run `docker compose --profile=split up` in your Ghost clone
+- If you want to test the full e2e flow to Tinybird, set the `PROXY_TARGET=https://api.tinybird.co/v0/events` value in your `.env` file in this repo. Otherwise the analytics service will use the `/local-proxy` mock endpoint, which does not forward events to Tinybird.
+- Run `yarn docker:dev:ghost` in the root of this repo
+- Visit your Ghost site's homepage at `http://localhost` and you should see a successful request in the network tab.
+
+## Test
+
+- `yarn test` run all tests locally
+- `docker compose run --rm test` or `yarn docker:test` run all tests in docker compose
+
+## Lint
+- `yarn lint` run eslint locally
+- `docker compose run --rm lint` or `yarn docker:lint` run eslint in docker compose
+
 ## Multi-Worktree Development
 
 This project supports running multiple worktrees simultaneously using Docker Compose. Each worktree can run its own isolated development environment with unique ports and container names.
@@ -71,39 +104,6 @@ docker compose up
 # work: http://localhost:3001  
 # scratch: http://localhost:3002
 ```
-
-## Develop
-
-1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
-
-## Build
-- `yarn build` to transpile Typescript to JS
-- `docker compose build` or `yarn docker:build` to build docker image
-
-## Run
-
-- `yarn dev` start development server locally
-- `docker compose up` or `yarn docker:dev` start development server in docker compose (includes Firestore emulator)
-- View: [http://localhost:3000](http://localhost:3000)
-
-## Run locally with Ghost in Docker
-
-Sometimes it's useful to test the full setup with Ghost pointing its tracker script to this analytics service running locally. This can be acheived relatively easily with Docker Compose:
-- Set the `tinybird:tracker:endpoint` to `http://localhost/.ghost/analytics/tb/web_analytics` in your Ghost config
-- Run `docker compose --profile=split up` in your Ghost clone
-- If you want to test the full e2e flow to Tinybird, set the `PROXY_TARGET=https://api.tinybird.co/v0/events` value in your `.env` file in this repo. Otherwise the analytics service will use the `/local-proxy` mock endpoint, which does not forward events to Tinybird.
-- Run `yarn docker:dev:ghost` in the root of this repo
-- Visit your Ghost site's homepage at `http://localhost` and you should see a successful request in the network tab.
-
-## Test
-
-- `yarn test` run all tests locally
-- `docker compose run --rm test` or `yarn docker:test` run all tests in docker compose
-
-## Lint
-- `yarn lint` run eslint locally
-- `docker compose run --rm lint` or `yarn docker:lint` run eslint in docker compose
 
 # Copyright & License 
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,11 +1,9 @@
-name: traffic-analytics
-
 services:
   firestore:
     image: google/cloud-sdk:emulators
     command: ["/app/firestore-wrapper.sh"]
     ports:
-      - 8080:8080
+      - ${FIRESTORE_PORT:-8080}:8080
     volumes:
       - ./docker/firestore/firestore-wrapper.sh:/app/firestore-wrapper.sh:ro
     environment:
@@ -25,7 +23,7 @@ services:
       dockerfile: Dockerfile
     command: ["yarn", "dev"]
     ports:
-      - 3000:3000
+      - ${ANALYTICS_PORT:-3000}:3000
     volumes:
       - .:/app
       - node_modules_volume:/app/node_modules


### PR DESCRIPTION
Support for running multiple worktrees simultaneously with isolated Docker environments. Each worktree can now run its own development server, tests, and services without port conflicts or container name collisions.

The previous Docker setup used hardcoded ports and project names, making it impossible to run multiple worktrees simultaneously. This created bottlenecks for developers wanting to work on multiple features in parallel.

Modified compose.yml to use environment variables for port configuration and leverage COMPOSE_PROJECT_NAME for automatic container isolation. Added comprehensive documentation with setup examples for different worktree configurations.

Enables true parallel development workflows where developers can have multiple isolated environments running simultaneously across different worktrees.

This setup is completely optional, and should not effect any existing clones.