### PR TITLE
Improved deployment pipeline with separate staging and production workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,12 +81,12 @@ jobs:
           done
 
   deploy:
-    name: Deploy
+    name: Deploy to Staging
     runs-on: ubuntu-latest
     needs: build
     strategy:
       matrix:
-        environment: [staging, production]
+        environment: [staging]
         region: [europe-west4]
         include:
           - region: europe-west4

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,58 @@
+name: Deploy to Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to deploy (e.g., v1.2.3)'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  GCP_PROJECT_ID: ghost-traffic-analytics
+  GCP_WORKFLOW_IDENTITY_PROVIDER: projects/460065119042/locations/global/workloadIdentityPools/github-oidc-analytics/providers/github-provider-analytics
+  DOCKER_IMAGE: europe-docker.pkg.dev/ghost-traffic-analytics/traffic-analytics/traffic-analytics
+
+jobs:
+  deploy-production:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: [production]
+        region: [europe-west4]
+        include:
+          - region: europe-west4
+            region_name: netherlands
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Validate version format
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Version must be in format v1.2.3"
+            exit 1
+          fi
+
+      - name: Check if release exists
+        run: |
+          if ! git tag -l | grep -q "^${{ inputs.version }}$"; then
+            echo "Error: Release ${{ inputs.version }} does not exist"
+            exit 1
+          fi
+
+      - name: "Deploy (${{ matrix.environment }} | ${{ matrix.region }})"
+        uses: "./.github/actions/deploy-gcp-cloud-run"
+        with:
+          environment: ${{ matrix.environment }}
+          region: ${{ matrix.region }}
+          service: >-
+            ${{ contains(matrix.environment, 'staging') && 'stg' || 'prd' }}-${{ matrix.region_name }}-traffic-analytics
+          image: ${{ env.DOCKER_IMAGE }}:${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Get current version
+        id: current-version
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          echo "current=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Calculate new version
+        id: new-version
+        run: |
+          CURRENT_VERSION="${{ steps.current-version.outputs.current }}"
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          MAJOR=${VERSION_PARTS[0]}
+          MINOR=${VERSION_PARTS[1]}
+          PATCH=${VERSION_PARTS[2]}
+          
+          case "${{ inputs.bump_type }}" in
+            "major")
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            "minor")
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            "patch")
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+          
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create release branch
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git checkout -b release/${{ steps.new-version.outputs.version }}
+
+      - name: Update package.json version
+        run: |
+          npm version ${{ steps.new-version.outputs.version }} --no-git-tag-version
+
+      - name: Commit version bump
+        run: |
+          git add package.json
+          git commit -m "Bump version to ${{ steps.new-version.outputs.version }}"
+
+      - name: Push release branch
+        run: |
+          git push origin release/${{ steps.new-version.outputs.version }}
+
+      - name: Create tag
+        run: |
+          git tag ${{ steps.new-version.outputs.tag }}
+          git push origin ${{ steps.new-version.outputs.tag }}
+
+      - name: Create GitHub release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.new-version.outputs.tag }}
+          release_name: Release ${{ steps.new-version.outputs.tag }}
+          body: |
+            Release ${{ steps.new-version.outputs.tag }}
+            
+            This release was created automatically from the release workflow.
+          draft: false
+          prerelease: false
+
+      - name: Create pull request to merge release back to main
+        uses: actions/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: release/${{ steps.new-version.outputs.version }}
+          base: main
+          title: "Release ${{ steps.new-version.outputs.tag }} - Merge back to main"
+          body: |
+            Automatic PR to merge release ${{ steps.new-version.outputs.tag }} back to main.
+            
+            This updates the version in package.json on the main branch.
+          commit-message: "Merge release ${{ steps.new-version.outputs.tag }} back to main"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,33 @@ Sometimes it's useful to test the full setup with Ghost pointing its tracker scr
 - `yarn lint` run eslint locally
 - `docker compose run --rm lint` or `yarn docker:lint` run eslint in docker compose
 
+## Deployment
+
+### Staging
+- **Automatic**: Merging to `main` branch automatically deploys to staging environment
+- **Manual**: Use "Run workflow" on the [Build & Deploy](../../actions/workflows/build.yml) action
+
+### Production
+
+#### Creating a Release
+1. Go to [Actions > Create Release](../../actions/workflows/release.yml)
+2. Click "Run workflow"
+3. Select the bump type: `patch`, `minor`, or `major`
+4. This will:
+   - Calculate the new version based on current package.json
+   - Create a release branch with the version bump
+   - Tag the release and create GitHub release
+   - Create PR to merge version bump back to main
+
+#### Deploying to Production
+1. Go to [Actions > Deploy to Production](../../actions/workflows/deploy-production.yml)
+2. Click "Run workflow"
+3. Enter the release version to deploy (e.g., `v1.2.3`)
+4. This deploys the specified release to production
+
+### Rollback
+- Use the [Rollback](../../actions/workflows/rollback.yml) workflow to rollback to a previous version
+
 # Copyright & License 
 
 Copyright (c) 2013-2025 Ghost Foundation - Released under the [MIT license](LICENSE).


### PR DESCRIPTION
Previously the deployment pipeline deployed to both staging and production on every merge to main, making it risky to test changes before production deployment.

Created a two-step deployment process:
- Staging deploys automatically on merge to main for safe testing
- Production requires manual release creation and separate deployment
- Added automated version bumping with semantic versioning
- Release workflow creates release branches and merges back to main

This enables safer development by allowing validation in staging before production deployment, and provides better control over when releases are created versus deployed.