### PR TITLE
Fixed default compose project name

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,3 +1,4 @@
+name: traffic-analytics
 services:
   firestore:
     image: google/cloud-sdk:emulators


### PR DESCRIPTION
The previous commit to enable multi-worktree Docker Compose projects to run in parallel inadvertently removed the default project name, which is used when the COMPOSE_PROJECT_NAME is not specified. This restores the previous default name, so as to avoid impacting any conventional clones.