### PR TITLE
Removed the preship command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "lint": "eslint src/ test/ --ext .js,.ts --cache",
     "lint:fix": "eslint src/ test/ --ext .js,.ts --cache --fix",
     "docker:lint": "docker compose run --rm lint",
-    "preship": "yarn test",
     "ship": "node scripts/ship.js"
   },
   "files": [


### PR DESCRIPTION
no refs

The `yarn ship` command tries to run tests first because of this `yarn preship` script. This step isn't really necessary, since we're not directly shipping from our local checkout, but rather raising a PR, which will need to pass tests before merging anyways.