### PR TITLE
Fixed remote in git push command to use $GHOST_UPSTREAM

### DIFF
--- a/scripts/ship.js
+++ b/scripts/ship.js
@@ -158,7 +158,7 @@ async function main() {
 
     // 8. Push the branch
     console.log('⬆️  Pushing release branch...');
-    exec(`git push origin ${branchName}`);
+    exec(`git push ${remoteName} ${branchName}`);
 
     // 9. Switch back to main
     exec('git checkout main');


### PR DESCRIPTION
no refs

The `ship.js` script had hardcoded `git push origin main` instead of using `$GHOST_UPSTREAM` if it's set. I have it set as `upstream` so it was failing. It will now use $GHOST_UPSTREAM if set, and fallback to origin.