### PR TITLE
Removed the environment matrix in favor of individual jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,13 +131,12 @@ jobs:
           git tag "v${{ needs.check-version-change.outputs.current-version }}"
           git push origin "v${{ needs.check-version-change.outputs.current-version }}"
 
-  deploy:
-    name: Deploy
+  deploy-staging:
+    name: Deploy to Staging
     runs-on: ubuntu-latest
     needs: [build, check-version-change]
     strategy:
       matrix:
-        environment: [staging, production]
         region: [europe-west4]
         include:
           - region: europe-west4
@@ -145,13 +144,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Deploy (${{ matrix.environment }} | ${{ matrix.region }})"
-        # Skip production deployment if version hasn't changed
-        if: matrix.environment != 'production' || needs.check-version-change.outputs.version-changed == 'true'
+      - name: "Deploy to Staging (${{ matrix.region }})"
         uses: "./.github/actions/deploy-gcp-cloud-run"
         with:
-          environment: ${{ matrix.environment }}
+          environment: staging
           region: ${{ matrix.region }}
-          service: >-
-            ${{ contains(matrix.environment, 'staging') && 'stg' || 'prd' }}-${{ matrix.region_name }}-traffic-analytics
+          service: stg-${{ matrix.region_name }}-traffic-analytics
+          image: ${{ env.DOCKER_IMAGE }}:${{ needs.build.outputs.version }}
+
+  deploy-production:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    needs: [build, check-version-change]
+    if: needs.check-version-change.outputs.version-changed == 'true'
+    strategy:
+      matrix:
+        region: [europe-west4]
+        include:
+          - region: europe-west4
+            region_name: netherlands
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Deploy to Production (${{ matrix.region }})"
+        uses: "./.github/actions/deploy-gcp-cloud-run"
+        with:
+          environment: production
+          region: ${{ matrix.region }}
+          service: prd-${{ matrix.region_name }}-traffic-analytics
           image: ${{ env.DOCKER_IMAGE }}:${{ needs.build.outputs.version }}


### PR DESCRIPTION
no refs

The previous workflow worked, but the "Deploy (production)" job in the matrix would still run, even though it skips the actual deployment step. The result is that Github Actions shows a big green checkmark next to "Deploy (production)", even though it wasn't really deployed, which is misleading and potentially scary.