### PR TITLE
Added event publishing to ingestion endpoint

### DIFF
--- a/.github/actions/lint-and-test/compose.ci.yml
+++ b/.github/actions/lint-and-test/compose.ci.yml
@@ -47,6 +47,7 @@ services:
       - PUBSUB_EMULATOR_HOST=pubsub:8085
       - PUBSUB_PROJECT_ID=traffic-analytics-ci
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
+      - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
     depends_on:
       firestore:
         condition: service_healthy

--- a/.github/actions/lint-and-test/compose.ci.yml
+++ b/.github/actions/lint-and-test/compose.ci.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - 8085:8085
     volumes:
-      - ../../docker/pubsub/start-pubsub.sh:/app/start-pubsub.sh:ro
+      - ./docker/pubsub/start-pubsub.sh:/app/start-pubsub.sh:ro
     environment:
       - PUBSUB_PROJECT_ID=traffic-analytics-ci
       - PUBSUB_PORT=8085

--- a/.github/actions/lint-and-test/compose.ci.yml
+++ b/.github/actions/lint-and-test/compose.ci.yml
@@ -16,16 +16,20 @@ services:
 
   pubsub:
     image: google/cloud-sdk:emulators
-    command: ["gcloud", "beta", "emulators", "pubsub", "start", "--host-port=0.0.0.0:8085", "--project=traffic-analytics-ci"]
+    command: ["/app/start-pubsub.sh"]
     ports:
       - 8085:8085
+    volumes:
+      - ../../docker/pubsub/start-pubsub.sh:/app/start-pubsub.sh:ro
     environment:
       - PUBSUB_PROJECT_ID=traffic-analytics-ci
+      - PUBSUB_PORT=8085
+      - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8085"]
+      test: ["CMD", "sh", "-c", "curl -f http://localhost:8085 && test -f /tmp/pubsub-ready"]
       interval: 5s
       timeout: 3s
-      retries: 5
+      retries: 10
 
   lint:
     image: ${DOCKER_IMAGE}
@@ -42,6 +46,7 @@ services:
       - FIRESTORE_PROJECT_ID=traffic-analytics-ci
       - PUBSUB_EMULATOR_HOST=pubsub:8085
       - PUBSUB_PROJECT_ID=traffic-analytics-ci
+      - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
     depends_on:
       firestore:
         condition: service_healthy

--- a/.github/actions/lint-and-test/compose.ci.yml
+++ b/.github/actions/lint-and-test/compose.ci.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - 8085:8085
     volumes:
-      - ./docker/pubsub/start-pubsub.sh:/app/start-pubsub.sh:ro
+      - ../../../docker/pubsub/start-pubsub.sh:/app/start-pubsub.sh:ro
     environment:
       - PUBSUB_PROJECT_ID=traffic-analytics-ci
       - PUBSUB_PORT=8085

--- a/compose.yml
+++ b/compose.yml
@@ -54,6 +54,7 @@ services:
       - PUBSUB_EMULATOR_HOST=pubsub:8085
       - PUBSUB_PROJECT_ID=traffic-analytics-dev
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
+      - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
     depends_on:
       firestore:
         condition: service_healthy
@@ -76,6 +77,7 @@ services:
       - PUBSUB_EMULATOR_HOST=pubsub:8085
       - PUBSUB_PROJECT_ID=traffic-analytics-dev
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
+      - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
     tty: true
     profiles: [testing]
     depends_on:

--- a/compose.yml
+++ b/compose.yml
@@ -18,16 +18,19 @@ services:
 
   pubsub:
     image: google/cloud-sdk:emulators
-    command: ["gcloud", "beta", "emulators", "pubsub", "start", "--host-port=0.0.0.0:8085", "--project=traffic-analytics-dev"]
+    command: ["/app/start-pubsub.sh"]
     ports:
       - ${PUBSUB_PORT:-8085}:8085
+    volumes:
+      - ./docker/pubsub/start-pubsub.sh:/app/start-pubsub.sh:ro
     environment:
       - PUBSUB_PROJECT_ID=traffic-analytics-dev
+      - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8085"]
+      test: ["CMD", "sh", "-c", "curl -f http://localhost:8085 && test -f /tmp/pubsub-ready"]
       interval: 5s
       timeout: 3s
-      retries: 5
+      retries: 10
     stop_grace_period: 5s
 
   analytics-service:
@@ -50,6 +53,7 @@ services:
       - FIRESTORE_PROJECT_ID=traffic-analytics-dev
       - PUBSUB_EMULATOR_HOST=pubsub:8085
       - PUBSUB_PROJECT_ID=traffic-analytics-dev
+      - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
     depends_on:
       firestore:
         condition: service_healthy
@@ -66,10 +70,12 @@ services:
     env_file:
       - .env
     environment:
+      - NODE_ENV=testing
       - FIRESTORE_EMULATOR_HOST=firestore:8080
       - FIRESTORE_PROJECT_ID=traffic-analytics-dev
       - PUBSUB_EMULATOR_HOST=pubsub:8085
       - PUBSUB_PROJECT_ID=traffic-analytics-dev
+      - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
     tty: true
     profiles: [testing]
     depends_on:

--- a/docker/pubsub/start-pubsub.sh
+++ b/docker/pubsub/start-pubsub.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Start the Pub/Sub emulator in the background
+echo "Starting Pub/Sub emulator..."
+gcloud beta emulators pubsub start --host-port=0.0.0.0:8085 --project=${PUBSUB_PROJECT_ID:-traffic-analytics-dev} &
+
+# Wait for the emulator to be ready
+echo "Waiting for Pub/Sub emulator to be ready..."
+timeout=30
+counter=0
+
+while ! curl -s http://localhost:8085 > /dev/null 2>&1; do
+    sleep 1
+    counter=$((counter + 1))
+    if [ $counter -ge $timeout ]; then
+        echo "Timeout waiting for Pub/Sub emulator to start"
+        exit 1
+    fi
+done
+
+echo "Pub/Sub emulator is ready!"
+
+# Create the required topics
+echo "Creating topics..."
+
+# Set environment variable for gcloud commands
+export PUBSUB_EMULATOR_HOST=localhost:8085
+
+# Create page hits raw topic
+if [ ! -z "$PUBSUB_TOPIC_PAGE_HITS_RAW" ]; then
+    echo "Creating topic: $PUBSUB_TOPIC_PAGE_HITS_RAW"
+    gcloud pubsub topics create "$PUBSUB_TOPIC_PAGE_HITS_RAW" --project=${PUBSUB_PROJECT_ID:-traffic-analytics-dev} 2>/dev/null || echo "Topic $PUBSUB_TOPIC_PAGE_HITS_RAW already exists"
+else
+    # Default topic name for development
+    echo "Creating default topic: traffic-analytics-page-hits-raw"
+    gcloud pubsub topics create "traffic-analytics-page-hits-raw" --project=${PUBSUB_PROJECT_ID:-traffic-analytics-dev} 2>/dev/null || echo "Topic traffic-analytics-page-hits-raw already exists"
+fi
+
+echo "Topic creation complete!"
+
+# Create a file to signal that setup is complete
+touch /tmp/pubsub-ready
+
+# Keep the script running (since the emulator is running in background)
+wait

--- a/docker/pubsub/start-pubsub.sh
+++ b/docker/pubsub/start-pubsub.sh
@@ -1,45 +1,50 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Start the Pub/Sub emulator in the background
+# This script starts the Pub/Sub emulator and creates the required topic
+# using the REST API to avoid authentication issues
+#
+# See:
+# https://cloud.google.com/pubsub/docs/emulator
+# https://cloud.google.com/pubsub/docs/create-topic#pubsub_create_topic-rest
+
+# Set defaults
+HOST=0.0.0.0:8085
+PROJECT_ID=${PUBSUB_PROJECT_ID:-traffic-analytics-dev}
+TOPIC_NAME=${PUBSUB_TOPIC_PAGE_HITS_RAW:-traffic-analytics-page-hits-raw}
+
 echo "Starting Pub/Sub emulator..."
-gcloud beta emulators pubsub start --host-port=0.0.0.0:8085 --project=${PUBSUB_PROJECT_ID:-traffic-analytics-dev} &
+echo "Host: $HOST"
+echo "Project: $PROJECT_ID"
+echo "Topic: $TOPIC_NAME"
+
+# Start the emulator in the background
+gcloud beta emulators pubsub start --host-port=${HOST} --project=${PROJECT_ID} &
 
 # Wait for the emulator to be ready
-echo "Waiting for Pub/Sub emulator to be ready..."
-timeout=30
-counter=0
-
-while ! curl -s http://localhost:8085 > /dev/null 2>&1; do
+until curl -f http://localhost:8085; do
+    echo "Waiting for Pub/Sub emulator to start..."
     sleep 1
-    counter=$((counter + 1))
-    if [ $counter -ge $timeout ]; then
-        echo "Timeout waiting for Pub/Sub emulator to start"
-        exit 1
-    fi
 done
 
 echo "Pub/Sub emulator is ready!"
 
-# Create the required topics
-echo "Creating topics..."
-
-# Set environment variable for gcloud commands
-export PUBSUB_EMULATOR_HOST=localhost:8085
-
-# Create page hits raw topic
-if [ ! -z "$PUBSUB_TOPIC_PAGE_HITS_RAW" ]; then
-    echo "Creating topic: $PUBSUB_TOPIC_PAGE_HITS_RAW"
-    gcloud pubsub topics create "$PUBSUB_TOPIC_PAGE_HITS_RAW" --project=${PUBSUB_PROJECT_ID:-traffic-analytics-dev} 2>/dev/null || echo "Topic $PUBSUB_TOPIC_PAGE_HITS_RAW already exists"
+# Create the topic via REST API
+echo "Creating topic: $TOPIC_NAME"
+if curl -s -o /dev/null -w "%{http_code}" -X PUT http://localhost:8085/v1/projects/${PROJECT_ID}/topics/${TOPIC_NAME} | grep -q "200"; then
+    echo "Topic created successfully: $TOPIC_NAME"
 else
-    # Default topic name for development
-    echo "Creating default topic: traffic-analytics-page-hits-raw"
-    gcloud pubsub topics create "traffic-analytics-page-hits-raw" --project=${PUBSUB_PROJECT_ID:-traffic-analytics-dev} 2>/dev/null || echo "Topic traffic-analytics-page-hits-raw already exists"
+    echo "Failed to create topic: $TOPIC_NAME"
+    exit 1
 fi
+
+# Verify topic was created by listing topics
+echo "Verifying topic creation..."
+curl -s http://localhost:8085/v1/projects/${PROJECT_ID}/topics
 
 echo "Topic creation complete!"
 
 # Create a file to signal that setup is complete
 touch /tmp/pubsub-ready
 
-# Keep the script running (since the emulator is running in background)
-wait
+# Keep the container running
+tail -f /dev/null

--- a/src/services/proxy/proxy.ts
+++ b/src/services/proxy/proxy.ts
@@ -3,6 +3,7 @@ import * as validators from './validators';
 import {parseReferrer} from './processors/url-referrer';
 import {parseUserAgent} from './processors/parse-user-agent';
 import {generateUserSignature} from './processors/user-signature';
+import {publishEvent} from '../events/publisher.js';
 
 // Accepts a request object
 // Does some processing — user agent parsing, geoip lookup, etc.
@@ -14,6 +15,29 @@ export async function processRequest(request: FastifyRequest, reply: FastifyRepl
         parseUserAgent(request);
         parseReferrer(request);
         await generateUserSignature(request);
+
+        // Publish raw page hit event to Pub/Sub (if topic is configured)
+        // This is fire-and-forget - don't let Pub/Sub errors break the proxy
+        const topic = process.env.PUBSUB_TOPIC_PAGE_HITS_RAW;
+        if (topic) {
+            publishEvent({
+                topic,
+                payload: {
+                    timestamp: new Date().toISOString(),
+                    method: request.method,
+                    url: request.url,
+                    headers: request.headers,
+                    body: request.body,
+                    ip: request.ip
+                }
+            }).catch((error) => {
+                // Log the error but don't let it affect the request
+                request.log.warn({
+                    error: error.message,
+                    topic
+                }, 'Failed to publish page hit event - continuing with request');
+            });
+        }
     } catch (error) {
         reply.code(500).send(error);
         throw error; // Re-throw to let Fastify handle it

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -6,10 +6,10 @@ import type {FastifyRequest, FastifyReply} from 'fastify';
 /**
  * Get logger configuration based on environment
  */
-export function getLoggerConfig(): LoggerOptions | false {
+export function getLoggerConfig(): LoggerOptions {
     // Disable logging in test environment
     if (process.env.NODE_ENV === 'testing') {
-        return false;
+        return {level: 'silent'};
     }
 
     // Development configuration - simple pretty logs
@@ -57,6 +57,6 @@ export function getLoggerConfig(): LoggerOptions | false {
 }
 
 // Create the default logger instance
-const logger = pino(getLoggerConfig() || {});
+const logger = pino(getLoggerConfig());
 
 export default logger;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-661/analytics-service-should-batch-events-when-sending-to-tinybird

This commit is the smallest change to test out publishing to our new GCP Pub/Sub topic in staging and production. It publishes events the topic on every request, and continues to forward the requests to Tinybird as usual. 