### PR TITLE
Switched all references to GCP project ID to the default variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,5 @@ PROXY_TARGET=http://localhost:3000/local-proxy
 # Options: memory, firestore
 SALT_STORE_TYPE=memory
 
-# Firestore Configuration (when SALT_STORE_TYPE=firestore)
-FIRESTORE_PROJECT_ID=traffic-analytics-dev
-# FIRESTORE_EMULATOR_HOST is automatically set by docker-compose
+# Google Cloud Project Configuration
+GOOGLE_CLOUD_PROJECT=traffic-analytics-dev

--- a/.github/actions/lint-and-test/compose.ci.yml
+++ b/.github/actions/lint-and-test/compose.ci.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - 8080:8080
     environment:
-      - FIRESTORE_PROJECT_ID=traffic-analytics-ci
+      - GOOGLE_CLOUD_PROJECT=traffic-analytics-ci
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080"]
       interval: 5s
@@ -22,7 +22,7 @@ services:
     volumes:
       - ../../../docker/pubsub/start-pubsub.sh:/app/start-pubsub.sh:ro
     environment:
-      - PUBSUB_PROJECT_ID=traffic-analytics-ci
+      - GOOGLE_CLOUD_PROJECT=traffic-analytics-ci
       - PUBSUB_PORT=8085
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
     healthcheck:
@@ -42,10 +42,9 @@ services:
     command: ["yarn", "test"]
     environment:
       - NODE_ENV=testing
+      - GOOGLE_CLOUD_PROJECT=traffic-analytics-ci
       - FIRESTORE_EMULATOR_HOST=firestore:8080
-      - FIRESTORE_PROJECT_ID=traffic-analytics-ci
       - PUBSUB_EMULATOR_HOST=pubsub:8085
-      - PUBSUB_PROJECT_ID=traffic-analytics-ci
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
       - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
     depends_on:

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Copy `.env.example` to `.env` and configure as needed:
 # Salt Store Configuration
 SALT_STORE_TYPE=memory  # Options: memory, firestore
 
-# Firestore Configuration (when SALT_STORE_TYPE=firestore)
-FIRESTORE_PROJECT_ID=traffic-analytics-dev
+# Google Cloud Project Configuration
+GOOGLE_CLOUD_PROJECT=traffic-analytics-dev
 
 # Multi-worktree Configuration (optional)
 COMPOSE_PROJECT_NAME=traffic-analytics-main  # Default project name

--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./docker/firestore/firestore-wrapper.sh:/app/firestore-wrapper.sh:ro
     environment:
-      - FIRESTORE_PROJECT_ID=traffic-analytics-dev
+      - GOOGLE_CLOUD_PROJECT=traffic-analytics-dev
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080"]
       interval: 5s
@@ -24,7 +24,7 @@ services:
     volumes:
       - ./docker/pubsub/start-pubsub.sh:/app/start-pubsub.sh:ro
     environment:
-      - PUBSUB_PROJECT_ID=traffic-analytics-dev
+      - GOOGLE_CLOUD_PROJECT=traffic-analytics-dev
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
     healthcheck:
       test: ["CMD", "sh", "-c", "curl -f http://localhost:8085 && test -f /tmp/pubsub-ready"]
@@ -49,10 +49,9 @@ services:
       - .env
     environment:
       - NODE_ENV=${NODE_ENV:-development}
+      - GOOGLE_CLOUD_PROJECT=traffic-analytics-dev
       - FIRESTORE_EMULATOR_HOST=firestore:8080
-      - FIRESTORE_PROJECT_ID=traffic-analytics-dev
       - PUBSUB_EMULATOR_HOST=pubsub:8085
-      - PUBSUB_PROJECT_ID=traffic-analytics-dev
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
       - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
     depends_on:
@@ -72,10 +71,9 @@ services:
       - .env
     environment:
       - NODE_ENV=testing
+      - GOOGLE_CLOUD_PROJECT=traffic-analytics-dev
       - FIRESTORE_EMULATOR_HOST=firestore:8080
-      - FIRESTORE_PROJECT_ID=traffic-analytics-dev
       - PUBSUB_EMULATOR_HOST=pubsub:8085
-      - PUBSUB_PROJECT_ID=traffic-analytics-dev
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
       - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
     tty: true

--- a/docker/pubsub/start-pubsub.sh
+++ b/docker/pubsub/start-pubsub.sh
@@ -9,7 +9,7 @@
 
 # Set defaults
 HOST=0.0.0.0:8085
-PROJECT_ID=${PUBSUB_PROJECT_ID:-traffic-analytics-dev}
+PROJECT_ID=${GOOGLE_CLOUD_PROJECT:-traffic-analytics-dev}
 TOPIC_NAME=${PUBSUB_TOPIC_PAGE_HITS_RAW:-traffic-analytics-page-hits-raw}
 
 echo "Starting Pub/Sub emulator..."

--- a/src/services/events/publisher.ts
+++ b/src/services/events/publisher.ts
@@ -12,7 +12,7 @@ class EventPublisher {
 
     private constructor() {
         this.pubsub = new PubSub({
-            projectId: process.env.PUBSUB_PROJECT_ID || 'traffic-analytics-dev'
+            projectId: process.env.GOOGLE_CLOUD_PROJECT || 'traffic-analytics-dev'
         });
     }
 

--- a/src/services/salt-store/SaltStoreFactory.ts
+++ b/src/services/salt-store/SaltStoreFactory.ts
@@ -19,11 +19,11 @@ export function createSaltStore(config?: SaltStoreConfig): ISaltStore {
     case 'memory':
         return new MemorySaltStore();
     case 'firestore': {
-        const projectId = config?.projectId || process.env.FIRESTORE_PROJECT_ID;
+        const projectId = config?.projectId || process.env.GOOGLE_CLOUD_PROJECT;
         const databaseId = config?.databaseId || process.env.FIRESTORE_DATABASE_ID;
         
         if (!projectId) {
-            throw new Error('Firestore project ID is required. Provide it via config.projectId or FIRESTORE_PROJECT_ID environment variable');
+            throw new Error('Firestore project ID is required. Provide it via config.projectId or GOOGLE_CLOUD_PROJECT environment variable');
         }
         
         if (!databaseId) {

--- a/test/integration/app.test.ts
+++ b/test/integration/app.test.ts
@@ -334,7 +334,7 @@ describe('Fastify App', () => {
 
         it('should publish page hit events to Pub/Sub topic', async () => {
             const pubsub = new PubSub({
-                projectId: process.env.PUBSUB_PROJECT_ID || 'traffic-analytics-dev'
+                projectId: process.env.GOOGLE_CLOUD_PROJECT || 'traffic-analytics-dev'
             });
 
             const topic = process.env.PUBSUB_TOPIC_PAGE_HITS_RAW || 'traffic-analytics-page-hits-raw';

--- a/test/integration/services/events/publisher.test.ts
+++ b/test/integration/services/events/publisher.test.ts
@@ -20,7 +20,7 @@ describe('Publisher Integration Tests', () => {
 
         // Initialize PubSub client for testing
         pubsub = new PubSub({
-            projectId: process.env.PUBSUB_PROJECT_ID || 'traffic-analytics-dev'
+            projectId: process.env.GOOGLE_CLOUD_PROJECT || 'traffic-analytics-dev'
         });
 
         // Create the test topic

--- a/test/unit/services/salt-store/SaltStoreFactory.test.ts
+++ b/test/unit/services/salt-store/SaltStoreFactory.test.ts
@@ -34,17 +34,17 @@ describe('SaltStoreFactory', () => {
 
         it('should throw error when creating firestore store without projectId', () => {
             // Ensure no environment variables are set
-            vi.stubEnv('FIRESTORE_PROJECT_ID', '');
+            vi.stubEnv('GOOGLE_CLOUD_PROJECT', '');
             vi.stubEnv('FIRESTORE_DATABASE_ID', '');
             
             const config: SaltStoreConfig = {type: 'firestore', databaseId: 'test-db'};
             
-            expect(() => createSaltStore(config)).toThrow('Firestore project ID is required. Provide it via config.projectId or FIRESTORE_PROJECT_ID environment variable');
+            expect(() => createSaltStore(config)).toThrow('Firestore project ID is required. Provide it via config.projectId or GOOGLE_CLOUD_PROJECT environment variable');
         });
 
         it('should throw error when creating firestore store without databaseId', () => {
             // Ensure no environment variables are set
-            vi.stubEnv('FIRESTORE_PROJECT_ID', '');
+            vi.stubEnv('GOOGLE_CLOUD_PROJECT', '');
             vi.stubEnv('FIRESTORE_DATABASE_ID', '');
             
             const config: SaltStoreConfig = {type: 'firestore', projectId: 'test-project'};
@@ -93,7 +93,7 @@ describe('SaltStoreFactory', () => {
 
         it('should create firestore store from environment variables', () => {
             vi.stubEnv('SALT_STORE_TYPE', 'firestore');
-            vi.stubEnv('FIRESTORE_PROJECT_ID', 'env-project');
+            vi.stubEnv('GOOGLE_CLOUD_PROJECT', 'env-project');
             vi.stubEnv('FIRESTORE_DATABASE_ID', 'env-database');
             
             const store = createSaltStore();
@@ -102,7 +102,7 @@ describe('SaltStoreFactory', () => {
         });
 
         it('should use environment variables when config values are not provided', () => {
-            vi.stubEnv('FIRESTORE_PROJECT_ID', 'env-project');
+            vi.stubEnv('GOOGLE_CLOUD_PROJECT', 'env-project');
             vi.stubEnv('FIRESTORE_DATABASE_ID', 'env-database');
             
             const config: SaltStoreConfig = {type: 'firestore'};


### PR DESCRIPTION
no refs

Cloud Run automatically passes the project id to the service via the `GOOGLE_CLOUD_PROJECT` environment variable. The application was using multiple difference service-specific variables for this value, e.g. `FIRESTORE_PROJECT_ID`, which isn't necessary and adds confusion and configuration complexity.

This change harmonizes this everywhere, so we always just use `GOOGLE_CLOUD_PROJECT` — this way we don't have to pass the same value to our service multiple times in staging/production.