### PR TITLE
Fixed CORS error due to x-site-uuid header

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -45,7 +45,7 @@ const app = fastify({
 app.register(fastifyCors, {
     origin: '*',
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Origin', 'X-Requested-With', 'Content-Type', 'Accept', 'Authorization']
+    allowedHeaders: ['Origin', 'X-Requested-With', 'Content-Type', 'Accept', 'Authorization', 'x-site-uuid']
 });
 
 app.addHook('onRequest', (request, _reply, done) => {

--- a/test/integration/app.test.ts
+++ b/test/integration/app.test.ts
@@ -422,5 +422,21 @@ describe('Fastify App', () => {
                 process.env.PUBSUB_TOPIC_PAGE_HITS_RAW = originalTopic;
             }
         });
+
+        it('should allow x-site-uuid header in CORS preflight requests', async function () {
+            await request(proxyServer)
+                .options('/tb/web_analytics')
+                .set('Origin', 'https://main.ghost.org')
+                .set('Access-Control-Request-Method', 'POST')
+                .set('Access-Control-Request-Headers', 'x-site-uuid, content-type')
+                .expect(204)
+                .expect('Access-Control-Allow-Origin', '*')
+                .expect(function (res: Response) {
+                    const allowedHeaders = res.headers['access-control-allow-headers'];
+                    if (!allowedHeaders || !allowedHeaders.toLowerCase().includes('x-site-uuid')) {
+                        throw new Error('x-site-uuid header should be allowed in CORS');
+                    }
+                });
+        });
     });
 });


### PR DESCRIPTION
Since we added the `x-site-uuid` header from Ghost, the requests from the `ghost-stats` script have been failing due to a CORS error:

```
main.ghost.org/:1 Access to fetch at 'https://traffic-analytics.ghostinfra.net/tb/web_analytics?name=analytics_events&token=p.eyJ1IjogIjVhOWRjMjQ1LWQyNjEtNGU4MC05ZDYzLWY4ZTliOTNhY2I3NCIsICJpZCI6ICIyNTQ5ZmZhYy1mZDZjLTQ5NmUtOTU4Ny1jZTgxOGE1MDlmNDkiLCAiaG9zdCI6ICJldV9zaGFyZWQifQ.5sfIJ7JYTGdXMsvP7AkbzcbHXBCIHPtcxUaGsAJaDMA' from origin 'https://main.ghost.org' has been blocked by CORS policy: Request header field x-site-uuid is not allowed by Access-Control-Allow-Headers in preflight response.
```

This commit should fix this error, by adding the `x-site-uuid` header to the list of allowed headers in the fastifyCors configuration.