### PR TITLE
Extracted logging hooks into a fastify plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@tryghost/referrer-parser": "0.1.7",
     "dotenv": "16.5.0",
     "fastify": "5.4.0",
+    "fastify-plugin": "^5.0.1",
     "pino": "9.7.0",
     "ua-parser-js": "1.0.40"
   }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@tryghost/referrer-parser": "0.1.7",
     "dotenv": "16.5.0",
     "fastify": "5.4.0",
-    "fastify-plugin": "^5.0.1",
+    "fastify-plugin": "5.0.1",
     "pino": "9.7.0",
     "ua-parser-js": "1.0.40"
   }

--- a/src/plugins/logging.ts
+++ b/src/plugins/logging.ts
@@ -45,4 +45,6 @@ async function loggingPlugin(fastify: FastifyInstance) {
     });
 }
 
+// Wrapping in `fp` makes these hooks global, so they apply to all routes
+// Without this, these hooks would only apply to routes registered in the same plugin
 export default fp(loggingPlugin);

--- a/src/plugins/logging.ts
+++ b/src/plugins/logging.ts
@@ -1,0 +1,48 @@
+import {FastifyInstance} from 'fastify';
+import fp from 'fastify-plugin';
+
+async function loggingPlugin(fastify: FastifyInstance) {
+    fastify.addHook('onRequest', async (request) => {
+        const PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT;
+        const traceHeader = request.headers['x-cloud-trace-context'] as string;
+        if (traceHeader && PROJECT_ID) {
+            const traceId = traceHeader.split('/')[0];
+            const traceContext = {
+                'logging.googleapis.com/trace': `projects/${PROJECT_ID}/traces/${traceId}`
+            };
+
+            request.log = request.log.child(traceContext);
+        }
+
+        request.log.info({
+            httpRequest: {
+                requestMethod: request.method,
+                requestUrl: request.url,
+                userAgent: request.headers['user-agent'],
+                remoteIp: request.ip,
+                referer: request.headers.referer,
+                protocol: `${request.protocol.toUpperCase()}/${request.raw.httpVersion}`,
+                requestSize: String(request.raw.headers['content-length'] || 0)
+            }
+        }, 'incoming request');
+    });
+
+    fastify.addHook('onResponse', async (request, reply) => {
+        request.log.info({
+            httpRequest: {
+                requestMethod: request.method,
+                requestUrl: request.url,
+                userAgent: request.headers['user-agent'],
+                remoteIp: request.ip,
+                referer: request.headers.referer,
+                protocol: `${request.protocol.toUpperCase()}/${request.raw.httpVersion}`,
+                requestSize: String(request.raw.headers['content-length'] || 0),
+                responseSize: String(reply.getHeader('content-length') || 0),
+                status: reply.statusCode,
+                latency: `${(reply.elapsedTime / 1000).toFixed(9)}s`
+            }
+        }, 'request completed');
+    });
+}
+
+export default fp(loggingPlugin);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3192,7 +3192,7 @@ fast-uri@^3.0.0, fast-uri@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.6.tgz#88f130b77cfaea2378d56bf970dea21257a68748"
   integrity sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==
 
-fastify-plugin@^5.0.0, fastify-plugin@^5.0.1:
+fastify-plugin@5.0.1, fastify-plugin@^5.0.0, fastify-plugin@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-5.0.1.tgz#82d44e6fe34d1420bb5a4f7bee434d501e41939f"
   integrity sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==


### PR DESCRIPTION
We've been adding lots of functionality to the main `app.ts` file and it's beginning to get a little hard to follow. In Fastify, it's a common pattern to extract functionality into plugins, and register them in the main app. This commit is the first move in this direction, pulling out the logging hooks specifically into their own plugin.