### PR TITLE
Added `@tryghost/config` for configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,5 @@ dist*
 .actsecrets
 
 scratch/
+
+config.development.json

--- a/README.md
+++ b/README.md
@@ -12,19 +12,21 @@ Traffic Analytics Service - A web analytics proxy for Ghost that processes and e
 
 ## Configuration
 
-Copy `.env.example` to `.env` and configure as needed:
+Copy `config.example.json` to `config.development.json` and configure as needed:
 
-```bash
-# Salt Store Configuration
-SALT_STORE_TYPE=memory  # Options: memory, firestore
-
-# Google Cloud Project Configuration
-GOOGLE_CLOUD_PROJECT=traffic-analytics-dev
-
-# Multi-worktree Configuration (optional)
-COMPOSE_PROJECT_NAME=traffic-analytics-main  # Default project name
-ANALYTICS_PORT=3000                           # Analytics service port (default: 3000)  
-FIRESTORE_PORT=8080                          # Firestore emulator port (default: 8080)
+```json
+{
+  "SALT_STORE_TYPE": "memory",
+  "GOOGLE_CLOUD_PROJECT": "traffic-analytics-dev",
+  "PORT": 3000,
+  "LOG_LEVEL": "info",
+  "PROXY_TARGET": "http://localhost:3000/local-proxy",
+  "LOG_PROXY_REQUESTS": "true",
+  "ENABLE_SALT_CLEANUP_SCHEDULER": "true",
+  "FIRESTORE_DATABASE_ID": "",
+  "PUBSUB_TOPIC_PAGE_HITS_RAW": "",
+  "TRUST_PROXY": "true"
+}
 ```
 
 ## Develop

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,12 @@
+{
+    "PORT": 3000,
+    "LOG_LEVEL": "info",
+    "PROXY_TARGET": "http://localhost:3000/local-proxy",
+    "TRUST_PROXY": "true",
+    "LOG_PROXY_REQUESTS": "true",
+    "SALT_STORE_TYPE": "memory",
+    "ENABLE_SALT_CLEANUP_SCHEDULER": "true",
+    "GOOGLE_CLOUD_PROJECT": "traffic-analytics-dev",
+    "FIRESTORE_DATABASE_ID": "",
+    "PUBSUB_TOPIC_PAGE_HITS_RAW": ""
+}

--- a/config.testing.json
+++ b/config.testing.json
@@ -1,0 +1,12 @@
+{
+    "PORT": 3000,
+    "LOG_LEVEL": "silent",
+    "PROXY_TARGET": "http://localhost:3000/local-proxy",
+    "TRUST_PROXY": "true",
+    "LOG_PROXY_REQUESTS": "false",
+    "SALT_STORE_TYPE": "memory",
+    "ENABLE_SALT_CLEANUP_SCHEDULER": "false",
+    "GOOGLE_CLOUD_PROJECT": "traffic-analytics-test",
+    "FIRESTORE_DATABASE_ID": "",
+    "PUBSUB_TOPIC_PAGE_HITS_RAW": ""
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@fastify/http-proxy": "11.2.0",
     "@google-cloud/firestore": "7.11.1",
     "@google-cloud/pubsub": "5.1.0",
+    "@tryghost/config": "0.2.27",
     "@tryghost/errors": "1.3.8",
     "@tryghost/referrer-parser": "0.1.7",
     "dotenv": "16.5.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@tryghost/config": "0.2.27",
     "@tryghost/errors": "1.3.8",
     "@tryghost/referrer-parser": "0.1.7",
-    "dotenv": "16.5.0",
     "fastify": "5.4.0",
     "fastify-plugin": "5.0.1",
     "pino": "9.7.0",

--- a/server.ts
+++ b/server.ts
@@ -1,9 +1,10 @@
 import app from './src/app';
 import {fileURLToPath} from 'url';
+import config from '@tryghost/config';
 
 const isMainModule = process.argv[1] === fileURLToPath(import.meta.url);
 
-const port: number = parseInt(process.env.PORT || '3000', 10);
+const port: number = config.get('PORT');
 
 // Start the server if this file is run directly
 if (isMainModule) {

--- a/server.ts
+++ b/server.ts
@@ -4,7 +4,7 @@ import config from '@tryghost/config';
 
 const isMainModule = process.argv[1] === fileURLToPath(import.meta.url);
 
-const port: number = config.get('PORT');
+const port: number = parseInt(config.get('PORT'), 10);
 
 // Start the server if this file is run directly
 if (isMainModule) {

--- a/src/services/events/publisher.ts
+++ b/src/services/events/publisher.ts
@@ -1,5 +1,6 @@
 import {PubSub} from '@google-cloud/pubsub';
 import logger from '../../utils/logger.js';
+import config from '@tryghost/config';
 
 export interface PublishEventOptions {
     topic: string;
@@ -12,7 +13,7 @@ class EventPublisher {
 
     private constructor() {
         this.pubsub = new PubSub({
-            projectId: process.env.GOOGLE_CLOUD_PROJECT || 'traffic-analytics-dev'
+            projectId: config.get('GOOGLE_CLOUD_PROJECT')
         });
     }
 

--- a/src/services/proxy/proxy.ts
+++ b/src/services/proxy/proxy.ts
@@ -5,6 +5,7 @@ import {parseReferrer} from './processors/url-referrer';
 import {parseUserAgent} from './processors/parse-user-agent';
 import {generateUserSignature} from './processors/user-signature';
 import {publishEvent} from '../events/publisher.js';
+import config from '@tryghost/config';
 
 // Accepts a request object
 // Does some processing — user agent parsing, geoip lookup, etc.
@@ -17,7 +18,7 @@ export async function processRequest(request: FastifyRequest, reply: FastifyRepl
     try {
         // Publish raw page hit event to Pub/Sub BEFORE any processing (if topic is configured)
         // This is fire-and-forget - don't let Pub/Sub errors break the proxy
-        const topic = process.env.PUBSUB_TOPIC_PAGE_HITS_RAW;
+        const topic = config.get('PUBSUB_TOPIC_PAGE_HITS_RAW') as string;
         if (topic) {
             try {
                 await publishEvent({

--- a/src/services/salt-store/SaltStoreFactory.ts
+++ b/src/services/salt-store/SaltStoreFactory.ts
@@ -14,7 +14,7 @@ export type SaltStoreConfig = {
 };
 
 export function createSaltStore(saltStoreConfig?: SaltStoreConfig): ISaltStore {
-    const storeType = saltStoreConfig?.type || (config.get('SALT_STORE_TYPE') as SaltStoreType);
+    const storeType = saltStoreConfig?.type || (config.get('SALT_STORE_TYPE') as SaltStoreType) || 'memory';
 
     switch (storeType) {
     case 'memory':

--- a/src/services/salt-store/SaltStoreFactory.ts
+++ b/src/services/salt-store/SaltStoreFactory.ts
@@ -1,6 +1,7 @@
 import type {ISaltStore} from './ISaltStore';
 import {MemorySaltStore} from './MemorySaltStore';
 import {FirestoreSaltStore} from './FirestoreSaltStore';
+import config from '@tryghost/config';
 
 export type SaltStoreType = 'memory' | 'file' | 'firestore';
 
@@ -12,15 +13,15 @@ export type SaltStoreConfig = {
     collectionName?: string;
 };
 
-export function createSaltStore(config?: SaltStoreConfig): ISaltStore {
-    const storeType = config?.type || (process.env.SALT_STORE_TYPE as SaltStoreType) || 'memory';
+export function createSaltStore(saltStoreConfig?: SaltStoreConfig): ISaltStore {
+    const storeType = saltStoreConfig?.type || (config.get('SALT_STORE_TYPE') as SaltStoreType);
 
     switch (storeType) {
     case 'memory':
         return new MemorySaltStore();
     case 'firestore': {
-        const projectId = config?.projectId || process.env.GOOGLE_CLOUD_PROJECT;
-        const databaseId = config?.databaseId || process.env.FIRESTORE_DATABASE_ID;
+        const projectId = saltStoreConfig?.projectId || config.get('GOOGLE_CLOUD_PROJECT');
+        const databaseId = saltStoreConfig?.databaseId || config.get('FIRESTORE_DATABASE_ID');
         
         if (!projectId) {
             throw new Error('Firestore project ID is required. Provide it via config.projectId or GOOGLE_CLOUD_PROJECT environment variable');
@@ -30,7 +31,7 @@ export function createSaltStore(config?: SaltStoreConfig): ISaltStore {
             throw new Error('Firestore database ID is required. Provide it via config.databaseId or FIRESTORE_DATABASE_ID environment variable');
         }
         
-        return new FirestoreSaltStore(projectId, databaseId, config?.collectionName);
+        return new FirestoreSaltStore(projectId, databaseId, saltStoreConfig?.collectionName);
     }
     case 'file':
         throw new Error('File salt store is not implemented yet');

--- a/src/services/user-signature/UserSignatureService.ts
+++ b/src/services/user-signature/UserSignatureService.ts
@@ -1,6 +1,7 @@
 import {ISaltStore} from '../salt-store';
 import crypto from 'crypto';
 import logger from '../../utils/logger';
+import config from '@tryghost/config';
 
 /**
  * Service for generating privacy-preserving user signatures.
@@ -28,7 +29,7 @@ export class UserSignatureService {
      */
     private startCleanupScheduler() {
         // Only start scheduler in production (not during testing)
-        if (process.env.NODE_ENV === 'testing' || process.env.ENABLE_SALT_CLEANUP_SCHEDULER === 'false') {
+        if (process.env.NODE_ENV === 'testing' || config.get('ENABLE_SALT_CLEANUP_SCHEDULER') === 'false') {
             return;
         }
 

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -1,0 +1,10 @@
+declare module '@tryghost/config' {
+    interface Config {
+        get<T = unknown>(key: string): T;
+        set(key: string, value: unknown): void;
+        has(key: string): boolean;
+    }
+    
+    const config: Config;
+    export default config;
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,6 +2,7 @@ import pino from 'pino';
 import type {LoggerOptions} from 'pino';
 import type {PrettyOptions} from 'pino-pretty';
 import type {FastifyRequest, FastifyReply} from 'fastify';
+import config from '@tryghost/config';
 
 /**
  * Get logger configuration based on environment
@@ -15,7 +16,7 @@ export function getLoggerConfig(): LoggerOptions {
     // Development configuration - simple pretty logs
     if (process.env.NODE_ENV === 'development') {
         return {
-            level: process.env.LOG_LEVEL || 'info',
+            level: config.get('LOG_LEVEL'),
             transport: {
                 target: 'pino-pretty',
                 options: {
@@ -44,7 +45,7 @@ export function getLoggerConfig(): LoggerOptions {
 
     // Production / staging configuration - full JSON logs
     return {
-        level: process.env.LOG_LEVEL || 'info',
+        level: config.get('LOG_LEVEL'),
         messageKey: 'message',
         formatters: {
             level: (label) => {

--- a/test/unit/services/salt-store/SaltStoreFactory.test.ts
+++ b/test/unit/services/salt-store/SaltStoreFactory.test.ts
@@ -3,20 +3,28 @@ import {createSaltStore, SaltStoreConfig} from '../../../../src/services/salt-st
 import {MemorySaltStore} from '../../../../src/services/salt-store/MemorySaltStore';
 import {FirestoreSaltStore} from '../../../../src/services/salt-store/FirestoreSaltStore';
 import type {ISaltStore} from '../../../../src/services/salt-store/ISaltStore';
+import config from '@tryghost/config';
+
+vi.mock('@tryghost/config');
 
 describe('SaltStoreFactory', () => {
     beforeEach(() => {
-        // Clear any environment variables for tests
-        vi.unstubAllEnvs();
+        vi.clearAllMocks();
     });
 
     afterEach(() => {
-        // Clean up after each test
-        vi.unstubAllEnvs();
+        vi.clearAllMocks();
     });
 
     describe('createSaltStore', () => {
         it('should create a memory salt store by default', () => {
+            vi.mocked(config.get).mockImplementation((key) => {
+                if (key === 'SALT_STORE_TYPE') {
+                    return 'memory';
+                }
+                return undefined;
+            });
+
             const store = createSaltStore();
 
             expect(store).toBeInstanceOf(MemorySaltStore);
@@ -26,39 +34,45 @@ describe('SaltStoreFactory', () => {
         });
 
         it('should create a memory salt store with explicit memory config', () => {
-            const config: SaltStoreConfig = {type: 'memory'};
-            const store = createSaltStore(config);
+            const saltStoreConfig: SaltStoreConfig = {type: 'memory'};
+            const store = createSaltStore(saltStoreConfig);
 
             expect(store).toBeInstanceOf(MemorySaltStore);
         });
 
         it('should throw error when creating firestore store without projectId', () => {
-            // Ensure no environment variables are set
-            vi.stubEnv('GOOGLE_CLOUD_PROJECT', '');
-            vi.stubEnv('FIRESTORE_DATABASE_ID', '');
+            vi.mocked(config.get).mockImplementation((key) => {
+                if (key === 'GOOGLE_CLOUD_PROJECT') {
+                    return '';
+                }
+                if (key === 'FIRESTORE_DATABASE_ID') {
+                    return '';
+                }
+                return undefined;
+            });
             
-            const config: SaltStoreConfig = {type: 'firestore', databaseId: 'test-db'};
+            const saltStoreConfig: SaltStoreConfig = {type: 'firestore', databaseId: 'test-db'};
             
-            expect(() => createSaltStore(config)).toThrow('Firestore project ID is required. Provide it via config.projectId or GOOGLE_CLOUD_PROJECT environment variable');
+            expect(() => createSaltStore(saltStoreConfig)).toThrow('Firestore project ID is required. Provide it via config.projectId or GOOGLE_CLOUD_PROJECT environment variable');
         });
 
         it('should throw error when creating firestore store without databaseId', () => {
             // Ensure no environment variables are set
-            vi.stubEnv('GOOGLE_CLOUD_PROJECT', '');
-            vi.stubEnv('FIRESTORE_DATABASE_ID', '');
+            // vi.stubEnv('GOOGLE_CLOUD_PROJECT', '');
+            // vi.stubEnv('FIRESTORE_DATABASE_ID', '');
             
-            const config: SaltStoreConfig = {type: 'firestore', projectId: 'test-project'};
+            const saltStoreConfig: SaltStoreConfig = {type: 'firestore', projectId: 'test-project'};
             
-            expect(() => createSaltStore(config)).toThrow('Firestore database ID is required. Provide it via config.databaseId or FIRESTORE_DATABASE_ID environment variable');
+            expect(() => createSaltStore(saltStoreConfig)).toThrow('Firestore database ID is required. Provide it via config.databaseId or FIRESTORE_DATABASE_ID environment variable');
         });
 
         it('should create a firestore salt store with complete config', () => {
-            const config: SaltStoreConfig = {
+            const saltStoreConfig: SaltStoreConfig = {
                 type: 'firestore',
                 projectId: 'test-project',
                 databaseId: 'test-database'
             };
-            const store = createSaltStore(config);
+            const store = createSaltStore(saltStoreConfig);
 
             expect(store).toBeInstanceOf(FirestoreSaltStore);
             expect(store).toHaveProperty('get');
@@ -68,70 +82,93 @@ describe('SaltStoreFactory', () => {
         });
 
         it('should create firestore store with custom project and collection', () => {
-            const config: SaltStoreConfig = {
+            const saltStoreConfig: SaltStoreConfig = {
                 type: 'firestore',
                 projectId: 'custom-project',
                 databaseId: 'custom-database',
                 collectionName: 'custom-salts'
             };
-            const store = createSaltStore(config);
+            const store = createSaltStore(saltStoreConfig);
 
             expect(store).toBeInstanceOf(FirestoreSaltStore);
         });
 
         it('should create firestore store with custom project, database and collection', () => {
-            const config: SaltStoreConfig = {
+            const saltStoreConfig: SaltStoreConfig = {
                 type: 'firestore',
                 projectId: 'custom-project',
                 databaseId: 'custom-database',
                 collectionName: 'custom-salts'
             };
-            const store = createSaltStore(config);
+            const store = createSaltStore(saltStoreConfig);
 
             expect(store).toBeInstanceOf(FirestoreSaltStore);
         });
 
-        it('should create firestore store from environment variables', () => {
-            vi.stubEnv('SALT_STORE_TYPE', 'firestore');
-            vi.stubEnv('GOOGLE_CLOUD_PROJECT', 'env-project');
-            vi.stubEnv('FIRESTORE_DATABASE_ID', 'env-database');
-            
+        it('should create firestore store from config', () => {
+            vi.mocked(config.get).mockImplementation((key) => {
+                if (key === 'SALT_STORE_TYPE') {
+                    return 'firestore';
+                }
+                if (key === 'GOOGLE_CLOUD_PROJECT') {
+                    return 'env-project';
+                }
+                if (key === 'FIRESTORE_DATABASE_ID') {
+                    return 'env-database';
+                }
+                return undefined;
+            });
+
             const store = createSaltStore();
 
             expect(store).toBeInstanceOf(FirestoreSaltStore);
         });
 
-        it('should use environment variables when config values are not provided', () => {
-            vi.stubEnv('GOOGLE_CLOUD_PROJECT', 'env-project');
-            vi.stubEnv('FIRESTORE_DATABASE_ID', 'env-database');
+        it('should use global config values when saltStoreConfig is not provided', () => {
+            vi.mocked(config.get).mockImplementation((key) => {
+                if (key === 'GOOGLE_CLOUD_PROJECT') {
+                    return 'env-project';
+                }
+                if (key === 'FIRESTORE_DATABASE_ID') {
+                    return 'env-database';
+                }
+                return undefined;
+            });
             
-            const config: SaltStoreConfig = {type: 'firestore'};
-            const store = createSaltStore(config);
+            const saltStoreConfig: SaltStoreConfig = {type: 'firestore'};
+            const store = createSaltStore(saltStoreConfig);
 
             expect(store).toBeInstanceOf(FirestoreSaltStore);
         });
 
         it('should throw error for file store type', () => {
-            const config: SaltStoreConfig = {type: 'file'};
+            const saltStoreConfig: SaltStoreConfig = {type: 'file'};
 
-            expect(() => createSaltStore(config)).toThrow('File salt store is not implemented yet');
+            expect(() => createSaltStore(saltStoreConfig)).toThrow('File salt store is not implemented yet');
         });
 
         it('should throw error for unknown store type', () => {
-            const config = {type: 'unknown' as 'memory'};
+            const saltStoreConfig = {type: 'unknown' as 'memory'};
 
-            expect(() => createSaltStore(config)).toThrow('Unknown salt store type: unknown');
+            expect(() => createSaltStore(saltStoreConfig)).toThrow('Unknown salt store type: unknown');
         });
 
         it('should handle undefined config gracefully', () => {
+            vi.mocked(config.get).mockImplementation((key) => {
+                if (key === 'SALT_STORE_TYPE') {
+                    return 'memory';
+                }
+                return undefined;
+            });
+
             const store = createSaltStore(undefined);
 
             expect(store).toBeInstanceOf(MemorySaltStore);
         });
 
         it('should handle empty config object', () => {
-            const config = {} as SaltStoreConfig;
-            const store = createSaltStore(config);
+            const saltStoreConfig = {} as SaltStoreConfig;
+            const store = createSaltStore(saltStoreConfig);
 
             expect(store).toBeInstanceOf(MemorySaltStore);
         });

--- a/test/unit/services/user-signature/UserSignatureService.test.ts
+++ b/test/unit/services/user-signature/UserSignatureService.test.ts
@@ -4,12 +4,16 @@ import {MemorySaltStore} from '../../../../src/services/salt-store/MemorySaltSto
 import type {ISaltStore} from '../../../../src/services/salt-store';
 import crypto from 'crypto';
 import logger from '../../../../src/utils/logger';
+import config from '@tryghost/config';
+
+vi.mock('@tryghost/config');
 
 describe('UserSignatureService', () => {
     let userSignatureService: UserSignatureService;
     let mockSaltStore: ISaltStore;
 
     beforeEach(() => {
+        vi.clearAllMocks();
         // Mock logger methods to avoid noise in tests
         vi.spyOn(logger, 'info').mockImplementation(() => {});
         vi.spyOn(logger, 'error').mockImplementation(() => {});
@@ -21,7 +25,7 @@ describe('UserSignatureService', () => {
     afterEach(() => {
         // Clean up any running schedulers
         userSignatureService.stopCleanupScheduler();
-        vi.restoreAllMocks();
+        vi.clearAllMocks();
         vi.clearAllTimers();
     });
 
@@ -204,9 +208,17 @@ describe('UserSignatureService', () => {
             });
 
             it('should not start scheduler when ENABLE_SALT_CLEANUP_SCHEDULER is false', () => {
-                const originalEnv = process.env.ENABLE_SALT_CLEANUP_SCHEDULER;
+                vi.mocked(config.get).mockImplementation((key) => {
+                    if (key === 'ENABLE_SALT_CLEANUP_SCHEDULER') {
+                        return 'false';
+                    }
+                    if (key === 'SALT_STORE_TYPE') {
+                        return 'memory';
+                    }
+                    return undefined;
+                });
+                
                 const originalNodeEnv = process.env.NODE_ENV;
-                process.env.ENABLE_SALT_CLEANUP_SCHEDULER = 'false';
                 process.env.NODE_ENV = 'production';
                 
                 const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
@@ -215,14 +227,18 @@ describe('UserSignatureService', () => {
                 expect(setTimeoutSpy).not.toHaveBeenCalled();
                 
                 service.stopCleanupScheduler();
-                process.env.ENABLE_SALT_CLEANUP_SCHEDULER = originalEnv;
                 process.env.NODE_ENV = originalNodeEnv;
             });
 
             it('should start scheduler when environment allows', () => {
-                const originalEnv = process.env.ENABLE_SALT_CLEANUP_SCHEDULER;
+                vi.mocked(config.get).mockImplementation((key) => {
+                    if (key === 'ENABLE_SALT_CLEANUP_SCHEDULER') {
+                        return 'true';
+                    }
+                    return undefined;
+                });
+                
                 const originalNodeEnv = process.env.NODE_ENV;
-                process.env.ENABLE_SALT_CLEANUP_SCHEDULER = 'true';
                 process.env.NODE_ENV = 'production';
                 
                 const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
@@ -239,7 +255,6 @@ describe('UserSignatureService', () => {
                 expect(delayMs).toBeLessThan(60 * 60 * 1000); // Less than 60 minutes
                 
                 service.stopCleanupScheduler();
-                process.env.ENABLE_SALT_CLEANUP_SCHEDULER = originalEnv;
                 process.env.NODE_ENV = originalNodeEnv;
             });
         });

--- a/test/unit/services/user-signature/UserSignatureService.test.ts
+++ b/test/unit/services/user-signature/UserSignatureService.test.ts
@@ -5,6 +5,7 @@ import type {ISaltStore} from '../../../../src/services/salt-store';
 import crypto from 'crypto';
 import logger from '../../../../src/utils/logger';
 import config from '@tryghost/config';
+import {mockConfigGet} from '../../../utils/config-mock';
 
 vi.mock('@tryghost/config');
 
@@ -208,14 +209,8 @@ describe('UserSignatureService', () => {
             });
 
             it('should not start scheduler when ENABLE_SALT_CLEANUP_SCHEDULER is false', () => {
-                vi.mocked(config.get).mockImplementation((key) => {
-                    if (key === 'ENABLE_SALT_CLEANUP_SCHEDULER') {
-                        return 'false';
-                    }
-                    if (key === 'SALT_STORE_TYPE') {
-                        return 'memory';
-                    }
-                    return undefined;
+                config.get = mockConfigGet({
+                    ENABLE_SALT_CLEANUP_SCHEDULER: 'false'
                 });
                 
                 const originalNodeEnv = process.env.NODE_ENV;
@@ -231,11 +226,8 @@ describe('UserSignatureService', () => {
             });
 
             it('should start scheduler when environment allows', () => {
-                vi.mocked(config.get).mockImplementation((key) => {
-                    if (key === 'ENABLE_SALT_CLEANUP_SCHEDULER') {
-                        return 'true';
-                    }
-                    return undefined;
+                config.get = mockConfigGet({
+                    ENABLE_SALT_CLEANUP_SCHEDULER: 'true'
                 });
                 
                 const originalNodeEnv = process.env.NODE_ENV;

--- a/test/utils/config-mock.ts
+++ b/test/utils/config-mock.ts
@@ -1,0 +1,20 @@
+import {vi} from 'vitest';
+
+export function mockConfigGet(overrides: Record<string, any> = {}) {
+    const defaults: Record<string, any> = {
+        PORT: 3000,
+        LOG_LEVEL: 'silent',
+        PROXY_TARGET: 'http://localhost:3000/local-proxy',
+        LOG_PROXY_REQUESTS: 'true',
+        SALT_STORE_TYPE: 'memory',
+        ENABLE_SALT_CLEANUP_SCHEDULER: 'true',
+        GOOGLE_CLOUD_PROJECT: 'test-project',
+        FIRESTORE_DATABASE_ID: 'test-db',
+        PUBSUB_TOPIC_PAGE_HITS_RAW: 'test-topic',
+        TRUST_PROXY: 'true'
+    };
+
+    return vi.fn((key: string) => {
+        return overrides[key] ?? defaults[key];
+    });
+}

--- a/test/utils/config-mock.ts
+++ b/test/utils/config-mock.ts
@@ -1,18 +1,10 @@
 import {vi} from 'vitest';
+import {readFileSync} from 'fs';
+import {join} from 'path';
 
 export function mockConfigGet(overrides: Record<string, any> = {}) {
-    const defaults: Record<string, any> = {
-        PORT: 3000,
-        LOG_LEVEL: 'silent',
-        PROXY_TARGET: 'http://localhost:3000/local-proxy',
-        LOG_PROXY_REQUESTS: 'true',
-        SALT_STORE_TYPE: 'memory',
-        ENABLE_SALT_CLEANUP_SCHEDULER: 'true',
-        GOOGLE_CLOUD_PROJECT: 'test-project',
-        FIRESTORE_DATABASE_ID: 'test-db',
-        PUBSUB_TOPIC_PAGE_HITS_RAW: 'test-topic',
-        TRUST_PROXY: 'true'
-    };
+    const configPath = join(__dirname, '../../config.testing.json');
+    const defaults = JSON.parse(readFileSync(configPath, 'utf8'));
 
     return vi.fn((key: string) => {
         return overrides[key] ?? defaults[key];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2639,7 +2639,7 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
-dotenv@*, dotenv@16.5.0:
+dotenv@*:
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.5.0.tgz#092b49f25f808f020050051d1ff258e404c78692"
   integrity sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,6 +1559,14 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@tryghost/config@0.2.27":
+  version "0.2.27"
+  resolved "https://registry.yarnpkg.com/@tryghost/config/-/config-0.2.27.tgz#b3506a48e8070253d5072b4eb0401d0732f0a6ef"
+  integrity sha512-wUf5FxcZ7k8sw0Xk1Glxb81ns2puFh5T9Tais6lbGq0UYJuXNcCJABAjs7F5R4gzrUQpZ81IbD8Fhxs9qk4i2w==
+  dependencies:
+    "@tryghost/root-utils" "^0.3.33"
+    nconf "^0.12.0"
+
 "@tryghost/errors@1.3.8":
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.3.8.tgz#d4212b52e876360b4fa8e303ae13ef86f3e95846"
@@ -1571,6 +1579,14 @@
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@tryghost/referrer-parser/-/referrer-parser-0.1.7.tgz#5230a960c7eaa69297ac8622d8dbddab17a9e15c"
   integrity sha512-qO5PqAdfDq4Aa/zTPpAxk2042Q5hdNOxTdMAO2SWDwF3qZS9yhGqlT0CfZcAtYvtnsr/Wb0aUClwVCP1VF/XXw==
+
+"@tryghost/root-utils@^0.3.33":
+  version "0.3.33"
+  resolved "https://registry.yarnpkg.com/@tryghost/root-utils/-/root-utils-0.3.33.tgz#208e3d15520131c2d4157c7e62fe74771a7a110f"
+  integrity sha512-Gmc/TrKtiRT7PV9JOPoSZ7jAOl/jJDWJFKNaLZbDQaiJIBP5C6PucqEfRqGb2Ko/S9j73HzEEBu6B7+qZMvbBg==
+  dependencies:
+    caller "^1.0.1"
+    find-root "^1.1.0"
 
 "@types/caseless@*":
   version "0.12.5"
@@ -2058,6 +2074,11 @@ async@^2.4.1:
   dependencies:
     lodash "^4.17.14"
 
+async@^3.0.0:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
+  integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -2307,6 +2328,11 @@ call-bound@^1.0.2, call-bound@^1.0.3, call-bound@^1.0.4:
     call-bind-apply-helpers "^1.0.2"
     get-intrinsic "^1.3.0"
 
+caller@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/caller/-/caller-1.1.0.tgz#46228555cfecb57d82bcd173b493f87cee9680fe"
+  integrity sha512-n+21IZC3j06YpCWaxmUy5AnVqhmCIM2bQtqQyy00HJlmStRt6kwDX5F9Z97pqwAB+G/tgSz6q/kUBbNyQzIubw==
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -2380,6 +2406,15 @@ cli-spinners@^2.5.0:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.2.tgz#1773a8f4b9c4d6ac31563df53b3fc1d79462fe41"
   integrity sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 cliui@^8.0.1:
   version "8.0.1"
@@ -3273,6 +3308,11 @@ find-my-way@^9.0.0:
     fast-querystring "^1.0.0"
     safe-regex2 "^5.0.0"
 
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
+
 find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -3856,6 +3896,11 @@ inherits@2, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ini@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
+  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
 internal-slot@^1.1.0:
   version "1.1.0"
@@ -4517,6 +4562,16 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+nconf@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/nconf/-/nconf-0.12.1.tgz#b0b91d2e32dc588fad19ac8bc5245e7472ebb4b9"
+  integrity sha512-p2cfF+B3XXacQdswUYWZ0w6Vld0832A/tuqjLBu3H1sfUcby4N2oVbGhyuCkZv+t3iY3aiFEj7gZGqax9Q2c1w==
+  dependencies:
+    async "^3.0.0"
+    ini "^2.0.0"
+    secure-keys "^1.0.0"
+    yargs "^16.1.1"
 
 no-case@^3.0.4:
   version "3.0.4"
@@ -5235,6 +5290,11 @@ secure-json-parse@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-4.0.0.tgz#2ee1b7581be38ab348bab5a3e49280ba80a89c85"
   integrity sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA==
+
+secure-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/secure-keys/-/secure-keys-1.0.0.tgz#f0c82d98a3b139a8776a8808050b824431087fca"
+  integrity sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==
 
 "semver@2 || 3 || 4 || 5":
   version "5.7.2"
@@ -6169,10 +6229,28 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
 yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^16.1.1:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yargs@^17.7.2:
   version "17.7.2"


### PR DESCRIPTION
This project has been using regular environment variables for all configuration prior to now. To maintain consistency with our other projects, we should aim to use established libraries when available. This updates all uses of `process.env` to use `config.get()` instead, except for specifically checking `NODE_ENV`. 

For now it maintains backwards compatibility — all the config keys are the same as the environment variables were, which means all caps and no nesting. We might want to change this eventually to take advantage of nested config, but that will require some changes to our staging/production environments as well. For now this should be sufficient. 