### PR TITLE
Updated publisher logs to use request logger

### DIFF
--- a/src/services/events/publisher.ts
+++ b/src/services/events/publisher.ts
@@ -1,10 +1,11 @@
 import {PubSub} from '@google-cloud/pubsub';
-import logger from '../../utils/logger.js';
 import config from '@tryghost/config';
+import type {FastifyBaseLogger} from 'fastify';
 
 export interface PublishEventOptions {
     topic: string;
     payload: Record<string, unknown>;
+    logger: FastifyBaseLogger;
 }
 
 class EventPublisher {
@@ -24,7 +25,7 @@ class EventPublisher {
         return EventPublisher.instance;
     }
 
-    async publishEvent({topic, payload}: PublishEventOptions): Promise<string> {
+    async publishEvent({topic, payload, logger}: PublishEventOptions): Promise<string> {
         try {
             const message = {
                 data: Buffer.from(JSON.stringify(payload)),
@@ -52,7 +53,7 @@ class EventPublisher {
     }
 }
 
-export const publishEvent = async ({topic, payload}: PublishEventOptions): Promise<string> => {
+export const publishEvent = async ({topic, payload, logger}: PublishEventOptions): Promise<string> => {
     const publisher = EventPublisher.getInstance();
-    return publisher.publishEvent({topic, payload});
+    return publisher.publishEvent({topic, payload, logger});
 };

--- a/src/services/proxy/proxy.ts
+++ b/src/services/proxy/proxy.ts
@@ -30,7 +30,8 @@ export async function processRequest(request: FastifyRequest, reply: FastifyRepl
                         headers: request.headers,
                         body: request.body,
                         ip: request.ip
-                    }
+                    },
+                    logger: request.log
                 });
             } catch (error) {
                 // Log the error but don't let it affect the request

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
             formats: ['es']
         },
         rollupOptions: {
-            external: ['fastify', '@fastify/cors', '@fastify/http-proxy', 'dotenv', 'ua-parser-js', '@tryghost/errors', '@google-cloud/pino-logging-gcp-config', 'pino'],
+            external: ['fastify', '@fastify/cors', '@fastify/http-proxy', 'dotenv', 'ua-parser-js', '@tryghost/errors', '@google-cloud/pino-logging-gcp-config', 'pino', '@tryghost/config'],
             output: {
                 entryFileNames: '[name].js',
                 preserveModules: true,


### PR DESCRIPTION
These logs were using the global logger rather than the request logger, so the logs weren't being correlated with the request trace correctly in GCP. 