### PR TITLE
Updated request logging to use full url

### DIFF
--- a/src/plugins/logging.ts
+++ b/src/plugins/logging.ts
@@ -10,10 +10,13 @@ async function loggingPlugin(fastify: FastifyInstance) {
             request.log = request.log.child(traceContext);
         }
 
+        // Construct full URL to match GCP request logs
+        const fullUrl = `${request.protocol}://${request.hostname}${request.url}`;
+        
         request.log.info({
             httpRequest: {
                 requestMethod: request.method,
-                requestUrl: request.url,
+                requestUrl: fullUrl,
                 userAgent: request.headers['user-agent'],
                 remoteIp: request.ip,
                 referer: request.headers.referer,
@@ -24,10 +27,13 @@ async function loggingPlugin(fastify: FastifyInstance) {
     });
 
     fastify.addHook('onResponse', async (request, reply) => {
+        // Construct full URL to match GCP request logs
+        const fullUrl = `${request.protocol}://${request.hostname}${request.url}`;
+        
         request.log.info({
             httpRequest: {
                 requestMethod: request.method,
-                requestUrl: request.url,
+                requestUrl: fullUrl,
                 userAgent: request.headers['user-agent'],
                 remoteIp: request.ip,
                 referer: request.headers.referer,


### PR DESCRIPTION
Our own request logs are only sending part of the url, whereas GCP's own request logs use the full URL including protocol and hostname. For the sake of consistency, this changes our own logs to use the full request URL.