### PR TITLE
Reverted change to url logging

### DIFF
--- a/src/plugins/logging.ts
+++ b/src/plugins/logging.ts
@@ -10,13 +10,10 @@ async function loggingPlugin(fastify: FastifyInstance) {
             request.log = request.log.child(traceContext);
         }
 
-        // Construct full URL to match GCP request logs
-        const fullUrl = `${request.protocol}://${request.hostname}${request.url}`;
-        
         request.log.info({
             httpRequest: {
                 requestMethod: request.method,
-                requestUrl: fullUrl,
+                requestUrl: request.url,
                 userAgent: request.headers['user-agent'],
                 remoteIp: request.ip,
                 referer: request.headers.referer,
@@ -27,13 +24,10 @@ async function loggingPlugin(fastify: FastifyInstance) {
     });
 
     fastify.addHook('onResponse', async (request, reply) => {
-        // Construct full URL to match GCP request logs
-        const fullUrl = `${request.protocol}://${request.hostname}${request.url}`;
-        
         request.log.info({
             httpRequest: {
                 requestMethod: request.method,
-                requestUrl: fullUrl,
+                requestUrl: request.url,
                 userAgent: request.headers['user-agent'],
                 remoteIp: request.ip,
                 referer: request.headers.referer,


### PR DESCRIPTION
This isn't working as well as I'd hoped — it's using `main.ghost.org` as the host, but it's omitting the `/.ghost/analytics` part of the path since we strip that in the API Gateway.

This just reverts the change so we'll continue to log the `request.url`, without the host and protocol.