### PR TITLE
Made .env file optional in docker compose configuration

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -46,7 +46,8 @@ services:
       - .:/app
       - node_modules_volume:/app/node_modules
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - NODE_ENV=${NODE_ENV:-development}
       - GOOGLE_CLOUD_PROJECT=traffic-analytics-dev


### PR DESCRIPTION
Docker compose would fail if .env file didn't exist, preventing development setup without environment configuration. Changed env_file configuration to use object syntax with required: false, allowing compose to start successfully even when .env is missing. This enables smoother development workflows where environment variables can be provided through other means.