### PR TITLE
Added setup-worktree script to help automate setting up new worktrees

### DIFF
--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Setup worktree configuration for Docker Compose
+# Usage: ./scripts/setup-worktree.sh [PORT_OFFSET]
+
+PORT_OFFSET=${1:-0}
+
+# Get worktree name from current directory
+WORKTREE_NAME=$(basename "$PWD")
+
+# Calculate ports using addition
+FIRESTORE_PORT=$((8080 + PORT_OFFSET * 100))
+PUBSUB_PORT=$((8085 + PORT_OFFSET * 100))
+ANALYTICS_PORT=$((3000 + PORT_OFFSET * 100))
+
+# Generate .env file
+cat > .env << EOF
+# Auto-generated worktree configuration
+# PORT_OFFSET: ${PORT_OFFSET}
+# Worktree: ${WORKTREE_NAME}
+
+COMPOSE_PROJECT_NAME=traffic-analytics-${WORKTREE_NAME}
+FIRESTORE_PORT=${FIRESTORE_PORT}
+PUBSUB_PORT=${PUBSUB_PORT}
+ANALYTICS_PORT=${ANALYTICS_PORT}
+EOF
+
+echo "Generated .env for worktree '${WORKTREE_NAME}' with PORT_OFFSET=${PORT_OFFSET}:"
+echo "  Project name: traffic-analytics-${WORKTREE_NAME}"
+echo "  Firestore: ${FIRESTORE_PORT}"
+echo "  PubSub: ${PUBSUB_PORT}"
+echo "  Analytics: ${ANALYTICS_PORT}"


### PR DESCRIPTION
When working with multiple worktrees, we need to avoid port conflicts. This is done by setting the ports in a .env file manually for each worktree. This is tedious to do manually, so this script helps automate it. 

Running `./scripts/setup-worktree.sh {OFFSET}` will generate a new .env file, which calculates the appropriate ports for each service based on the provided integer OFFSET, and set the COMPOSE_PROJECT_NAME appropriately to avoid conflicts with other worktrees. 