### PR TITLE
Removed production site from healthchecks

### DIFF
--- a/.github/workflows/healthchecks.yml
+++ b/.github/workflows/healthchecks.yml
@@ -17,8 +17,6 @@ jobs:
         environment:
           - name: main
             base_url: https://main.ghost.org
-          - name: chris
-            base_url: https://www.chrisraible.com
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
There is a change in Ghost required before these checks will pass. This hasn't yet been deployed to production, so these will fail every time. Removing these checks for now.