### PR TITLE
Added slack notification to the healthchecks job

### DIFF
--- a/.github/workflows/healthchecks.yml
+++ b/.github/workflows/healthchecks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   healthchecks:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 10
     
     strategy:
       fail-fast: false
@@ -21,6 +21,10 @@ jobs:
             base_url: https://www.chrisraible.com
     
     steps:
+      - name: Wake up site
+        run: |
+          curl -s -o /dev/null "${{ github.event.inputs.target_url || matrix.environment.base_url }}" &
+          
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -58,7 +62,7 @@ jobs:
           path: test-results/
           retention-days: 30
 
-      - name: Post a message in a channel
+      - name: Send slack notification if health checks fail
         uses: slackapi/slack-github-action@v2.1.0
         if: failure()
         with:

--- a/.github/workflows/healthchecks.yml
+++ b/.github/workflows/healthchecks.yml
@@ -17,6 +17,8 @@ jobs:
         environment:
           - name: main
             base_url: https://main.ghost.org
+          - name: chris
+            base_url: https://www.chrisraible.com
     
     steps:
       - name: Checkout code
@@ -55,6 +57,7 @@ jobs:
           name: test-results-${{ matrix.environment.name }}
           path: test-results/
           retention-days: 30
+
       - name: Post a message in a channel
         uses: slackapi/slack-github-action@v2.1.0
         if: failure()

--- a/.github/workflows/healthchecks.yml
+++ b/.github/workflows/healthchecks.yml
@@ -35,6 +35,7 @@ jobs:
         run: yarn playwright install --with-deps
 
       - name: Run health checks
+        id: healthchecks
         env:
           TEST_BASE_URL: ${{ github.event.inputs.target_url || matrix.environment.base_url }}
         run: yarn playwright test
@@ -54,3 +55,16 @@ jobs:
           name: test-results-${{ matrix.environment.name }}
           path: test-results/
           retention-days: 30
+      - name: Post a message in a channel
+        uses: slackapi/slack-github-action@v2.1.0
+        if: failure()
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "*Analytics Service Health Check Failed*: ${{ job.status }}\n${{ github.event.inputs.target_url || matrix.environment.base_url }}"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "Analytics Service Health Check Failed: ${{ job.status }}\n${{ github.event.inputs.target_url || matrix.environment.base_url }}"

--- a/.github/workflows/healthchecks.yml
+++ b/.github/workflows/healthchecks.yml
@@ -17,8 +17,6 @@ jobs:
         environment:
           - name: main
             base_url: https://main.ghost.org
-          - name: chris
-            base_url: https://www.chrisraible.com
     
     steps:
       - name: Wake up site

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     fullyParallel: true,
     forbidOnly: !!process.env.CI,
     retries: 0,
+    timeout: 60000, // 60 seconds
     workers: process.env.CI ? 1 : undefined,
     reporter: 'html',
   


### PR DESCRIPTION
So we know when they fail. We'll probably want this to trigger an ops genie alert or an incident in the future, at least if they fail in production, but for now a Slack notification should suffice.