### PR TITLE
Moved the local-proxy endpoint into the proxy plugin

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -26,9 +26,5 @@ app.get('/', async () => {
     return 'Hello World - Github Actions Deployment Test';
 });
 
-app.post('/local-proxy*', async () => {
-    return 'Hello World - From the local proxy';
-});
-
 export default app;
 

--- a/src/plugins/proxy.ts
+++ b/src/plugins/proxy.ts
@@ -44,6 +44,11 @@ function getProxyConfig(prefix: string): FastifyHttpProxyOptions {
 async function proxyPlugin(fastify: FastifyInstance) {
     // Register the analytics proxy
     fastify.register(fastifyHttpProxy, getProxyConfig('/tb/web_analytics'));
+    
+    // Register local proxy endpoint for development/testing
+    fastify.post('/local-proxy*', async () => {
+        return 'Hello World - From the local proxy';
+    });
 }
 
 export default fp(proxyPlugin);


### PR DESCRIPTION
The `/local-proxy` endpoint is closely coupled with the proxy itself, so this commit moves it into the proxy plugin along with the main proxy endpoint.