### PR TITLE
Added playwright traces for failing healthchecks

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   
     use: {
         baseURL: process.env.TEST_BASE_URL || 'https://main.ghost.org',
-        trace: 'on-first-retry'
+        trace: 'retain-on-failure'
     },
 
     projects: [


### PR DESCRIPTION
The healthchecks are failing ~50% of the time on staging, but we don't have the full traces when they run in CI, which makes it hard to debug them. This should add the full trace so we can inspect the DOM, console, network requests, etc. when failures occur.