### PR TITLE
Fixed playwright caching in healthchecks workflow

### DIFF
--- a/.github/workflows/healthchecks.yml
+++ b/.github/workflows/healthchecks.yml
@@ -49,6 +49,10 @@ jobs:
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: yarn playwright install --with-deps
+        
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: yarn playwright install-deps
 
       - name: Run health checks
         id: healthchecks

--- a/.github/workflows/healthchecks.yml
+++ b/.github/workflows/healthchecks.yml
@@ -35,16 +35,16 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Get installed Playwright version
+      - name: Get Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(yarn playwright --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+        run: echo "version=$(node -p "require('./package.json').devDependencies['@playwright/test']")" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/healthchecks.yml
+++ b/.github/workflows/healthchecks.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Send slack notification if health checks fail
         uses: slackapi/slack-github-action@v2.1.0
-        if: failure()
+        if: failure() && github.ref == 'refs/heads/main'
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
The playwright caching step was failing due to some kind of formatting error from GHA. This uses a different approach to get the current playwright version, which fixes the error and allows the workflow to complete successfully.