### PR TITLE
Added 3 staging sites to healthchecks

### DIFF
--- a/.github/workflows/healthchecks.yml
+++ b/.github/workflows/healthchecks.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Disable man-db trigger refreshes (https://github.com/actions/runner-images/issues/10977)
+        shell: bash
+        run: |
+          echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
+          sudo dpkg-reconfigure man-db
+
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(node -p "require('./package.json').devDependencies['@playwright/test']")" >> $GITHUB_OUTPUT

--- a/.github/workflows/healthchecks.yml
+++ b/.github/workflows/healthchecks.yml
@@ -15,8 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         environment:
-          - name: main
-            base_url: https://main.ghost.org
+          - name: staging-subdomain
+            base_url: https://traffic-analytics-subdomain.ghost.is/
+          - name: staging-custom-domain
+            base_url: https://traffic-analytics.ghst.pro/
+          - name: staging-subdirectory
+            base_url: https://traffic-analytics-subdirectory.ghost.is/blog/
     
     steps:
       - name: Wake up site

--- a/test/healthchecks/ghost-site.spec.ts
+++ b/test/healthchecks/ghost-site.spec.ts
@@ -1,12 +1,12 @@
 import {test, expect} from './fixtures';
 
 test.describe('Ghost site healthcheck', () => {
-    test('should make analytics request with 202 response', async ({page}) => {
+    test('should make analytics request with 202 response', async ({page, baseURL}) => {
         // Wait for the analytics request
         const analyticsRequestPromise = page.waitForRequest('**/.ghost/analytics/tb/web_analytics**');
         const analyticsResponsePromise = page.waitForResponse('**/.ghost/analytics/tb/web_analytics**');
         
-        await page.goto('/');
+        await page.goto(baseURL!);
         
         // Verify the analytics request was made
         const request = await analyticsRequestPromise;


### PR DESCRIPTION
This switches to using dedicated test sites on staging, rather than pointing to main.ghost.org. It covers a few different scenarios as well to ensure we haven't broken event ingestion for certain types of sites.

- Site without custom domain
- Site with custom domain
- Site with subdirectory