### PR TITLE
Updated deployment pipeline to also deploy worker to Cloud Run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,41 +165,22 @@ jobs:
     strategy:
       matrix:
         region: [europe-west4]
+        service: [analytics, worker]
         include:
           - region: europe-west4
             region_name: netherlands
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Deploy to Staging (${{ matrix.region }})"
+      - name: "Deploy to Staging (${{ matrix.region }}) - ${{ matrix.service }}"
         id: deploy-staging
         uses: "./.github/actions/deploy-gcp-cloud-run"
         with:
           environment: staging
           region: ${{ matrix.region }}
-          service: stg-${{ matrix.region_name }}-traffic-analytics
+          service: stg-${{ matrix.region_name }}-traffic-analytics${{ matrix.service == 'worker' && '-worker' || '' }}
           image: ${{ env.DOCKER_IMAGE }}:${{ needs.build.outputs.version }}
 
-      - name: Send slack notification for staging deployment
-        uses: slackapi/slack-github-action@v2.1.0
-        if: always()
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            text: "Traffic Analytics Staging Deployment: ${{ job.status }} (${{ matrix.region_name }})"
-            blocks:
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: "${{ job.status == 'success' && ':white_check_mark: *Traffic Analytics Staging Deployment*' || ':x: *Traffic Analytics Staging Deployment*' }}"
-              - type: "section"
-                fields:
-                  - type: "mrkdwn"
-                    text: "*Workflow:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
-            attachments:
-              - color: "${{ job.status == 'success' && 'good' || 'danger' }}"
-                fallback: "Traffic Analytics Staging Deployment: ${{ job.status }}"
 
   deploy-production:
     name: Deploy to Production
@@ -209,38 +190,83 @@ jobs:
     strategy:
       matrix:
         region: [europe-west4]
+        service: [analytics, worker]
         include:
           - region: europe-west4
             region_name: netherlands
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Deploy to Production (${{ matrix.region }})"
+      - name: "Deploy to Production (${{ matrix.region }}) - ${{ matrix.service }}"
         id: deploy-production
         uses: "./.github/actions/deploy-gcp-cloud-run"
         with:
           environment: production
           region: ${{ matrix.region }}
-          service: prd-${{ matrix.region_name }}-traffic-analytics
+          service: prd-${{ matrix.region_name }}-traffic-analytics${{ matrix.service == 'worker' && '-worker' || '' }}
           image: ${{ env.DOCKER_IMAGE }}:${{ needs.build.outputs.version }}
 
-      - name: Send slack notification for production deployment
+  notify-staging-complete:
+    name: Notify Staging Deployment Complete
+    runs-on: ubuntu-latest
+    needs: [deploy-staging]
+    if: always()
+    steps:
+      - name: Send consolidated slack notification for staging
         uses: slackapi/slack-github-action@v2.1.0
-        if: always()
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "Traffic Analytics Production Deployment: ${{ job.status }} (${{ matrix.region_name }})"
+            text: "Traffic Analytics Staging Deployment: ${{ needs.deploy-staging.result }} (netherlands)"
             blocks:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "${{ job.status == 'success' && ':rocket: *Traffic Analytics Production Deployment*' || ':x: *Traffic Analytics Production Deployment*' }}"
+                  text: "${{ needs.deploy-staging.result == 'success' && ':white_check_mark: *Traffic Analytics Staging Deployment*' || ':x: *Traffic Analytics Staging Deployment*' }}"
               - type: "section"
                 fields:
                   - type: "mrkdwn"
-                    text: "*Workflow:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+                    text: "*Services:*\n:gear: analytics, worker"
+                  - type: "mrkdwn"
+                    text: "*Region:*\n:earth_americas: netherlands"
+                  - type: "mrkdwn"
+                    text: "*Status:*\n${{ needs.deploy-staging.result == 'success' && ':large_green_circle: Success' || ':red_circle: Failed' }}"
+                  - type: "mrkdwn"
+                    text: "*Workflow:*\n:link: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
             attachments:
-              - color: "${{ job.status == 'success' && 'good' || 'danger' }}"
-                fallback: "Traffic Analytics Production Deployment: ${{ job.status }}"
+              - color: "${{ needs.deploy-staging.result == 'success' && 'good' || 'danger' }}"
+                fallback: "Traffic Analytics Staging Deployment: ${{ needs.deploy-staging.result }}"
+
+  notify-production-complete:
+    name: Notify Production Deployment Complete
+    runs-on: ubuntu-latest
+    needs: [deploy-production]
+    if: always()
+    steps:
+      - name: Send consolidated slack notification for production
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "Traffic Analytics Production Deployment: ${{ needs.deploy-production.result }} (netherlands)"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "${{ needs.deploy-production.result == 'success' && ':rocket: *Traffic Analytics Production Deployment*' || ':x: *Traffic Analytics Production Deployment*' }}"
+              - type: "section"
+                fields:
+                  - type: "mrkdwn"
+                    text: "*Services:*\n:gear: analytics, worker"
+                  - type: "mrkdwn"
+                    text: "*Region:*\n:earth_americas: netherlands"
+                  - type: "mrkdwn"
+                    text: "*Status:*\n${{ needs.deploy-production.result == 'success' && ':large_green_circle: Success' || ':red_circle: Failed' }}"
+                  - type: "mrkdwn"
+                    text: "*Workflow:*\n:link: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+            attachments:
+              - color: "${{ needs.deploy-production.result == 'success' && 'good' || 'danger' }}"
+                fallback: "Traffic Analytics Production Deployment: ${{ needs.deploy-production.result }}"
+


### PR DESCRIPTION
Our CI pipeline wasn't setup to deploy new revisions to our worker Cloud Run service, only the main analytics service. This adds a deployment step for the worker service for production and staging, and changes how the Slack notifications work to avoid duplicate notifications for each deployment. 