### PR TITLE
Fixed false production deployment notification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,7 +242,7 @@ jobs:
     name: Notify Production Deployment Complete
     runs-on: ubuntu-latest
     needs: [deploy-production]
-    if: always()
+    if: always() && needs.deploy-production.result != 'skipped'
     steps:
       - name: Send consolidated slack notification for production
         uses: slackapi/slack-github-action@v2.1.0


### PR DESCRIPTION
The last change to our deployment pipelines was triggering the "Notify Production Deployment" job even if the "Deploy Production" job itself didn't run, and it was reporting it as a failure. This should fix that to avoid the false failure notifications.