### PR TITLE
Pulled healthchecks into a reusable action

### DIFF
--- a/.github/actions/run-healthchecks/action.yml
+++ b/.github/actions/run-healthchecks/action.yml
@@ -1,0 +1,72 @@
+name: 'Run Health Checks'
+description: 'Run Playwright health checks against specified base URL'
+
+inputs:
+  base_url:
+    description: 'Base URL to run health checks against'
+    required: true
+  environment_name:
+    description: 'Environment name for artifact naming'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Wake up site
+      shell: bash
+      run: |
+        curl -s -o /dev/null "${{ inputs.base_url }}" &
+        
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'yarn'
+
+    - name: Install dependencies
+      shell: bash
+      run: yarn install --frozen-lockfile
+
+    - name: Disable man-db trigger refreshes
+      shell: bash
+      run: |
+        echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
+        sudo dpkg-reconfigure man-db
+
+    - name: Get Playwright version
+      id: playwright-version
+      shell: bash
+      run: echo "version=$(node -p "require('./package.json').devDependencies['@playwright/test']")" >> $GITHUB_OUTPUT
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      id: playwright-cache
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+    - name: Install Playwright browsers
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: yarn playwright install --with-deps
+      
+    - name: Install Playwright system dependencies
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: yarn playwright install-deps
+
+    - name: Run health checks
+      shell: bash
+      env:
+        TEST_BASE_URL: ${{ inputs.base_url }}
+      run: yarn playwright test
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: playwright-results-${{ inputs.environment_name }}
+        path: |
+          playwright-report/
+          test-results/
+        retention-days: 30

--- a/.github/workflows/healthchecks.yml
+++ b/.github/workflows/healthchecks.yml
@@ -29,62 +29,13 @@ jobs:
             base_url: https://traffic-analytics-subdirectory.ghost.io/blog/
     
     steps:
-      - name: Wake up site
-        run: |
-          curl -s -o /dev/null "${{ github.event.inputs.target_url || matrix.environment.base_url }}" &
-          
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Disable man-db trigger refreshes (https://github.com/actions/runner-images/issues/10977)
-        shell: bash
-        run: |
-          echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
-          sudo dpkg-reconfigure man-db
-
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "version=$(node -p "require('./package.json').devDependencies['@playwright/test']")" >> $GITHUB_OUTPUT
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
-
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: yarn playwright install --with-deps
-        
-      - name: Install Playwright system dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: yarn playwright install-deps
-
+      - uses: actions/checkout@v4
+      
       - name: Run health checks
-        id: healthchecks
-        env:
-          TEST_BASE_URL: ${{ github.event.inputs.target_url || matrix.environment.base_url }}
-        run: yarn playwright test
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        if: always()
+        uses: ./.github/actions/run-healthchecks
         with:
-          name: playwright-results-${{ matrix.environment.name }}
-          path: |
-            playwright-report/
-            test-results/
-          retention-days: 30
+          base_url: ${{ github.event.inputs.target_url || matrix.environment.base_url }}
+          environment_name: ${{ matrix.environment.name }}
 
       - name: Send slack notification if health checks fail
         uses: slackapi/slack-github-action@v2.1.0


### PR DESCRIPTION
I'd like to automatically run these healthchecks after each staging and production deploy so I don't have to do this manually. This pulls the healthcheck itself into a reusable action, which we will then be able to run in multiple workflows seamlessly.