### PR TITLE
Added a simple "black box" e2e test

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:unit:watch": "NODE_ENV=testing vitest watch test/unit",
     "test:integration": "NODE_ENV=testing vitest run --config vitest.config.integration.ts",
     "test:integration:watch": "NODE_ENV=testing vitest watch --config vitest.config.integration.ts",
+    "test:e2e": "NODE_ENV=testing vitest run test/e2e",
     "test:types": "tsc --noEmit",
     "test": "yarn test:types && yarn test:unit && yarn test:integration",
     "docker:test": "docker compose run --rm test",

--- a/test/e2e/web_analytics.test.ts
+++ b/test/e2e/web_analytics.test.ts
@@ -1,0 +1,26 @@
+import {describe, it, expect} from 'vitest';
+
+describe('E2E /tb/web_analytics', () => {
+    it('should process analytics request successfully', async () => {
+        const response = await fetch('http://localhost:3000/tb/web_analytics?token=test-token&name=pageview', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+                Referer: 'https://example.com/blog/post',
+                'x-site-uuid': '12345678-1234-1234-1234-123456789012'
+            },
+            body: JSON.stringify({
+                payload: {
+                    url: 'https://example.com/test-page',
+                    timestamp: '2024-01-01T00:00:00Z'
+                }
+            })
+        });
+
+        expect(response.status).toBe(200);
+        
+        const responseText = await response.text();
+        expect(responseText).toBe('Hello World - From the local proxy');
+    });
+});


### PR DESCRIPTION
Our current testing approach with integrations tests is overly complex. We don't currently have a simple test that simply makes a request to the service, and makes assertions that it receives the correct response. This is an initial test to do just that, so we can quickly verify that the service is running. A follow up commit will set this test up to run in CI, along with the other existing tests.