### PR TITLE
Setup healthchecks to run after deployments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,6 +238,110 @@ jobs:
               - color: "${{ needs.deploy-staging.result == 'success' && 'good' || 'danger' }}"
                 fallback: "Traffic Analytics Staging Deployment: ${{ needs.deploy-staging.result }}"
 
+  healthcheck-staging:
+    name: Health Check Staging
+    runs-on: ubuntu-latest
+    needs: [deploy-staging]
+    if: needs.deploy-staging.result == 'success'
+    timeout-minutes: 10
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        environment:
+          - name: staging-subdomain
+            base_url: https://traffic-analytics-subdomain.ghost.is/
+          - name: staging-custom-domain
+            base_url: https://traffic-analytics.ghst.pro/
+          - name: staging-subdirectory
+            base_url: https://traffic-analytics-subdirectory.ghost.is/blog/
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Run health checks
+        uses: ./.github/actions/run-healthchecks
+        with:
+          base_url: ${{ matrix.environment.base_url }}
+          environment_name: ${{ matrix.environment.name }}
+
+      - name: Send slack notification if health checks fail
+        uses: slackapi/slack-github-action@v2.1.0
+        if: failure()
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "Analytics Service Health Check Failed After Staging Deployment"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: ":rotating_light: *Analytics Service Health Check Failed After Staging Deployment*"
+              - type: "section"
+                fields:
+                  - type: "mrkdwn"
+                    text: "*Environment:*\n:computer: ${{ matrix.environment.name }}"
+                  - type: "mrkdwn"
+                    text: "*Target URL:*\n:globe_with_meridians: ${{ matrix.environment.base_url }}"
+                  - type: "mrkdwn"
+                    text: "*Workflow:*\n:gear: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+            attachments:
+              - color: "danger"
+                fallback: "Analytics Service Health Check Failed After Staging Deployment"
+
+  healthcheck-production:
+    name: Health Check Production
+    runs-on: ubuntu-latest
+    needs: [deploy-production]
+    if: needs.deploy-production.result == 'success'
+    timeout-minutes: 10
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        environment:
+          - name: production-subdomain
+            base_url: https://traffic-analytics-subdomain.ghost.io/
+          - name: production-custom-domain
+            base_url: https://traffic-analytics.ghost.org/
+          - name: production-subdirectory
+            base_url: https://traffic-analytics-subdirectory.ghost.io/blog/
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Run health checks
+        uses: ./.github/actions/run-healthchecks
+        with:
+          base_url: ${{ matrix.environment.base_url }}
+          environment_name: ${{ matrix.environment.name }}
+
+      - name: Send slack notification if health checks fail
+        uses: slackapi/slack-github-action@v2.1.0
+        if: failure()
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "Analytics Service Health Check Failed After Production Deployment"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: ":rotating_light: *Analytics Service Health Check Failed After Production Deployment*"
+              - type: "section"
+                fields:
+                  - type: "mrkdwn"
+                    text: "*Environment:*\n:computer: ${{ matrix.environment.name }}"
+                  - type: "mrkdwn"
+                    text: "*Target URL:*\n:globe_with_meridians: ${{ matrix.environment.base_url }}"
+                  - type: "mrkdwn"
+                    text: "*Workflow:*\n:gear: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+            attachments:
+              - color: "danger"
+                fallback: "Analytics Service Health Check Failed After Production Deployment"
+
   notify-production-complete:
     name: Notify Production Deployment Complete
     runs-on: ubuntu-latest


### PR DESCRIPTION
We have some basic liveness probes setup in GCP to ensure that deployments start up, but we don't have comprehensive checks to make sure the deployment is handling requests from Ghost properly. This commit runs our healthchecks on each environment right after a deployment succeeds, to ensure that the core functionality hasn't been broken by the deployment. 