### PR TITLE
Added message.ack() call

### DIFF
--- a/src/plugins/worker-plugin.ts
+++ b/src/plugins/worker-plugin.ts
@@ -20,6 +20,7 @@ async function workerPlugin(fastify: FastifyInstance) {
         subscriber.subscribe((message: Message) => {
             const messageData = message.data.toString();
             fastify.log.info({messageData}, 'Worker received message');
+            message.ack();
         });
     });
 


### PR DESCRIPTION
The worker is receiving the messages and logging them now, but not acking them, so pub/sub will continue resending the same messages. This adds an ack() so messages don't pile up.