### PR TITLE
Updated schema to allow `null` for location

### DIFF
--- a/src/schemas/v1/page-hit-raw-request.ts
+++ b/src/schemas/v1/page-hit-raw-request.ts
@@ -55,7 +55,7 @@ export const HeadersSchema = Type.Object({
 export const PayloadSchema = Type.Object({
     'user-agent': NonEmptyStringSchema,
     locale: NonEmptyStringSchema,
-    location: NonEmptyStringSchema,
+    location: Type.Union([NonEmptyStringSchema, Type.Null()]),
     referrer: Type.Union([URLSchema, Type.Null()]),
     pathname: NonEmptyStringSchema,
     href: URLSchema,
@@ -63,7 +63,7 @@ export const PayloadSchema = Type.Object({
     post_uuid: Type.Union([UUIDSchema, Type.Literal('undefined')]),
     post_type: Type.Union([Type.Literal('null'), Type.Literal('post'), Type.Literal('page')]),
     member_uuid: Type.Union([UUIDSchema, Type.Literal('undefined')]),
-    member_status: NonEmptyStringSchema
+    member_status: Type.Union([NonEmptyStringSchema, Type.Literal('undefined')])
 }, {
     additionalProperties: true // Allow processors to add os, browser, device, etc.
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,7 @@ import {FastifyRequest as FastifyRequestBase, FastifyReply as FastifyReplyBase} 
 export interface Payload {
     'user-agent': string;
     locale: string;
-    location: string;
+    location: string | null;
     referrer: string | null;
     parsedReferrer?: {
         source: string | null;

--- a/test/e2e/web_analytics.test.ts
+++ b/test/e2e/web_analytics.test.ts
@@ -129,26 +129,26 @@ describe('E2E /tb/web_analytics', () => {
     it('should accept real healthcheck request with null location and undefined member_status', async () => {
         // This is the exact request body that was causing 400 responses in healthchecks
         const healthcheckBody = {
-            "timestamp": "2025-06-23T23:23:55.030Z",
-            "action": "page_hit",
-            "version": "1",
-            "payload": {
-                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.7204.23 Safari/537.36",
-                "locale": "en-US",
-                "location": null,
-                "referrer": null,
-                "parsedReferrer": {
-                    "source": null,
-                    "medium": null,
-                    "url": null
+            timestamp: '2025-06-23T23:23:55.030Z',
+            action: 'page_hit',
+            version: '1',
+            payload: {
+                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.7204.23 Safari/537.36',
+                locale: 'en-US',
+                location: null,
+                referrer: null,
+                parsedReferrer: {
+                    source: null,
+                    medium: null,
+                    url: null
                 },
-                "pathname": "/",
-                "href": "https://traffic-analytics.ghst.pro/",
-                "site_uuid": "c7929de8-27d7-404e-b714-0fc774f701e6",
-                "post_uuid": "undefined",
-                "post_type": "null",
-                "member_uuid": "undefined",
-                "member_status": "undefined"
+                pathname: '/',
+                href: 'https://traffic-analytics.ghst.pro/',
+                site_uuid: 'c7929de8-27d7-404e-b714-0fc774f701e6',
+                post_uuid: 'undefined',
+                post_type: 'null',
+                member_uuid: 'undefined',
+                member_status: 'undefined'
             }
         };
 

--- a/test/e2e/web_analytics.test.ts
+++ b/test/e2e/web_analytics.test.ts
@@ -125,4 +125,48 @@ describe('E2E /tb/web_analytics', () => {
             expect(response.status).toBe(400);
         });
     });
+
+    it('should accept real healthcheck request with null location and undefined member_status', async () => {
+        // This is the exact request body that was causing 400 responses in healthchecks
+        const healthcheckBody = {
+            "timestamp": "2025-06-23T23:23:55.030Z",
+            "action": "page_hit",
+            "version": "1",
+            "payload": {
+                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.7204.23 Safari/537.36",
+                "locale": "en-US",
+                "location": null,
+                "referrer": null,
+                "parsedReferrer": {
+                    "source": null,
+                    "medium": null,
+                    "url": null
+                },
+                "pathname": "/",
+                "href": "https://traffic-analytics.ghst.pro/",
+                "site_uuid": "c7929de8-27d7-404e-b714-0fc774f701e6",
+                "post_uuid": "undefined",
+                "post_type": "null",
+                "member_uuid": "undefined",
+                "member_status": "undefined"
+            }
+        };
+
+        const queryString = new URLSearchParams(DEFAULT_QUERY_PARAMS).toString();
+        const url = `http://localhost:3000/tb/web_analytics?${queryString}`;
+        
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                ...DEFAULT_HEADERS,
+                'x-site-uuid': 'c7929de8-27d7-404e-b714-0fc774f701e6'
+            },
+            body: JSON.stringify(healthcheckBody)
+        });
+
+        expect(response.status).toBe(200);
+        
+        const responseText = await response.text();
+        expect(responseText).toBe('Hello World - From the local proxy');
+    });
 });

--- a/test/unit/schemas/v1/page-hit-raw-request.test.ts
+++ b/test/unit/schemas/v1/page-hit-raw-request.test.ts
@@ -218,6 +218,29 @@ describe('PageHitRawRequestSchema v1', () => {
         
             expect(Value.Check(PayloadSchema, invalidPayload)).toBe(false);
         });
+
+        it('should validate real healthcheck payload with null location and undefined member_status', () => {
+            const healthcheckPayload = {
+                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.7204.23 Safari/537.36',
+                locale: 'en-US',
+                location: null,
+                referrer: null,
+                parsedReferrer: {
+                    source: null,
+                    medium: null,
+                    url: null
+                },
+                pathname: '/',
+                href: 'https://traffic-analytics.ghst.pro/',
+                site_uuid: 'c7929de8-27d7-404e-b714-0fc774f701e6',
+                post_uuid: 'undefined',
+                post_type: 'null',
+                member_uuid: 'undefined',
+                member_status: 'undefined'
+            };
+            
+            expect(Value.Check(PayloadSchema, healthcheckPayload)).toBe(true);
+        });
     });
 
     describe('BodySchema', () => {


### PR DESCRIPTION
After deploying https://github.com/TryGhost/TrafficAnalytics/commit/48897f59133e8211ef53bcbbdf6e0f1653e25547 to staging, the healthchecks failed with a 400 response. The requests sent `location` with a `null` value, which apparently can happen and should be allowed (for now at least). This updates the schema to allow it. 