### PR TITLE
Updated schema to allow non-url referers

### DIFF
--- a/src/schemas/v1/page-hit-raw-request.ts
+++ b/src/schemas/v1/page-hit-raw-request.ts
@@ -56,7 +56,7 @@ export const PayloadSchema = Type.Object({
     'user-agent': NonEmptyStringSchema,
     locale: NonEmptyStringSchema,
     location: Type.Union([NonEmptyStringSchema, Type.Null()]),
-    referrer: Type.Union([URLSchema, Type.Null()]),
+    referrer: Type.Union([StringSchema, Type.Null()]),
     pathname: NonEmptyStringSchema,
     href: URLSchema,
     site_uuid: UUIDSchema,

--- a/test/unit/schemas/v1/page-hit-raw-request.test.ts
+++ b/test/unit/schemas/v1/page-hit-raw-request.test.ts
@@ -192,15 +192,6 @@ describe('PageHitRawRequestSchema v1', () => {
             expect(Value.Check(PayloadSchema, invalidPayload)).toBe(false);
         });
 
-        it('should reject invalid referrer URL', () => {
-            const invalidPayload = {
-                ...validPayload,
-                referrer: 'not-a-url'
-            };
-        
-            expect(Value.Check(PayloadSchema, invalidPayload)).toBe(false);
-        });
-
         it('should reject empty required strings', () => {
             const invalidPayload = {
                 ...validPayload,


### PR DESCRIPTION
The validation schema for page hits was overly restrictive for referers, throwing validation errors if referer wasn't a URL. We do in fact allow referers that aren't URLs for e.g. newsletters, so this changes to allowing any string, or `null`.