### PR TITLE
Refactored proxy endpoint to use `@fastify/reply-from` instead of `@fastify/http-proxy`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fastify/cors": "11.0.1",
-    "@fastify/http-proxy": "11.2.0",
+    "@fastify/reply-from": "12.1.0",
     "@fastify/type-provider-typebox": "5.1.0",
     "@google-cloud/firestore": "7.11.1",
     "@google-cloud/pino-logging-gcp-config": "1.0.6",

--- a/src/plugins/proxy.ts
+++ b/src/plugins/proxy.ts
@@ -1,47 +1,70 @@
-import {FastifyInstance} from 'fastify';
+import {FastifyInstance, FastifyRequest as FastifyRequestBase, FastifyReply as FastifyReplyBase} from 'fastify';
+import {Static} from '@sinclair/typebox';
 import fp from 'fastify-plugin';
-import fastifyHttpProxy, {FastifyHttpProxyOptions} from '@fastify/http-proxy';
-import {processRequest, validateRequestWithSchema} from '../services/proxy';
+import {processRequest} from '../services/proxy';
+import {FastifyRequest, FastifyReply} from '../types';
+import {QueryParamsSchema, HeadersSchema, BodySchema} from '../schemas/v1/page-hit-raw-request';
 
 async function proxyPlugin(fastify: FastifyInstance) {
-    // Register the analytics proxy using fastify-http-proxy with custom hooks
-    await fastify.register(fastifyHttpProxy, {
-        upstream: process.env.PROXY_TARGET || 'http://localhost:3000/local-proxy',
-        prefix: '/tb/web_analytics',
-        rewritePrefix: '', // Remove the prefix when forwarding
-        httpMethods: ['GET', 'POST', 'PUT', 'DELETE'],
-        preValidation: validateRequestWithSchema as FastifyHttpProxyOptions['preValidation'],
-        preHandler: processRequest as FastifyHttpProxyOptions['preHandler'],
-        replyOptions: {
-            onError: (reply, error) => {
-                // Log proxy errors with proper structure for GCP
-                const unwrappedError = 'error' in error ? error.error : error;
-                reply.log.error({
-                    err: {
-                        message: unwrappedError.message,
-                        stack: unwrappedError.stack,
-                        name: unwrappedError.name
-                    },
-                    httpRequest: {
-                        requestMethod: reply.request.method,
-                        requestUrl: reply.request.url,
-                        userAgent: reply.request.headers['user-agent'],
-                        remoteIp: reply.request.ip,
-                        referer: reply.request.headers.referer,
-                        protocol: `${reply.request.protocol.toUpperCase()}/${reply.request.raw.httpVersion}`,
-                        status: 502
-                    },
-                    upstream: process.env.PROXY_TARGET || 'http://localhost:3000/local-proxy',
-                    type: 'proxy_error'
-                }, 'Proxy error occurred');
-                reply.status(502).send({error: 'Proxy error'});
-            }
-        },
+    await fastify.register(import('@fastify/reply-from'), {
         disableRequestLogging: process.env.LOG_PROXY_REQUESTS === 'false'
     });
+
+    const handleProxyError = (request: FastifyRequest, reply: FastifyReply, error: unknown) => {
+        const unwrappedError = error && typeof error === 'object' && 'error' in error ? (error as {error: Error}).error : error as Error;
+        reply.log.error({
+            err: {
+                message: unwrappedError.message,
+                stack: unwrappedError.stack,
+                name: unwrappedError.name
+            },
+            httpRequest: {
+                requestMethod: request.method,
+                requestUrl: request.url,
+                userAgent: request.headers['user-agent'],
+                remoteIp: request.ip,
+                referer: request.headers.referer,
+                protocol: `${request.protocol.toUpperCase()}/${request.raw.httpVersion}`,
+                status: 502
+            },
+            upstream: process.env.PROXY_TARGET || 'http://localhost:3000/local-proxy',
+            type: 'proxy_error'
+        }, 'Proxy error occurred');
+        reply.status(502).send({error: 'Proxy error'});
+    };
+
+    const typedProcessRequest = async (
+        request: FastifyRequestBase<{
+            Querystring: Static<typeof QueryParamsSchema>;
+            Headers: Static<typeof HeadersSchema>;
+            Body: Static<typeof BodySchema>;
+        }>,
+        reply: FastifyReplyBase
+    ) => {
+        await processRequest(request as FastifyRequest, reply as FastifyReply);
+    };
+
+    fastify.post('/tb/web_analytics', {
+        schema: {
+            querystring: QueryParamsSchema,
+            headers: HeadersSchema,
+            body: BodySchema
+        },
+        preHandler: typedProcessRequest
+    }, async (request, reply) => {
+        try {
+            // Forward directly to the PROXY_TARGET with query params
+            const targetUrl = process.env.PROXY_TARGET || 'http://localhost:3000/local-proxy';
+            const url = new URL(request.url, 'http://localhost');
+            const fullTargetUrl = targetUrl + url.search;
+            await reply.from(fullTargetUrl);
+        } catch (error) {
+            handleProxyError(request as FastifyRequest, reply as FastifyReply, error);
+        }
+    });
     
-    // Register local proxy endpoint for development/testing
-    fastify.post('/local-proxy*', async () => {
+    // Default local proxy endpoint for development/testing
+    fastify.post('/local-proxy', async () => {
         return 'Hello World - From the local proxy';
     });
 }

--- a/src/schemas/v1/page-hit-raw-request.ts
+++ b/src/schemas/v1/page-hit-raw-request.ts
@@ -1,4 +1,5 @@
-import {Type, FormatRegistry} from '@sinclair/typebox';
+import {Type, FormatRegistry, Static} from '@sinclair/typebox';
+import {FastifyRequest as FastifyRequestBase} from 'fastify';
 import validator from '@tryghost/validator';
 
 // Register format validators for runtime validation using @tryghost/validator
@@ -83,3 +84,17 @@ export const PageHitRawRequestSchema = Type.Object({
     headers: HeadersSchema,
     body: BodySchema
 });
+
+// Fastify route schema configuration for analytics endpoints
+export const AnalyticsRouteSchema = {
+    querystring: QueryParamsSchema,
+    headers: HeadersSchema,
+    body: BodySchema
+};
+
+// TypeScript type for validated analytics requests
+export type ValidatedAnalyticsRequest = FastifyRequestBase<{
+    Querystring: Static<typeof QueryParamsSchema>;
+    Headers: Static<typeof HeadersSchema>;
+    Body: Static<typeof BodySchema>;
+}>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,16 +245,6 @@
   resolved "https://registry.yarnpkg.com/@fastify/forwarded/-/forwarded-3.0.0.tgz#0fc96cdbbb5a38ad453d2d5533a34f09b4949b37"
   integrity sha512-kJExsp4JCms7ipzg7SJ3y8DwmePaELHxKYtg+tZow+k0znUTf3cb+npgyqm8+ATZOdmfgfydIebPDWM172wfyA==
 
-"@fastify/http-proxy@11.2.0":
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/@fastify/http-proxy/-/http-proxy-11.2.0.tgz#d58122383ab59dcb78344e8a02fdf3ac2429730e"
-  integrity sha512-sHhAJEGnVefw3P4N/HDyo2lGagBwYUePXE8kXflKnNF+4vYxNItPMoNjETpIEYbuBeqoV7lHOgAKu0+y9K7SUA==
-  dependencies:
-    "@fastify/reply-from" "^12.0.2"
-    fast-querystring "^1.1.2"
-    fastify-plugin "^5.0.1"
-    ws "^8.18.0"
-
 "@fastify/merge-json-schemas@^0.2.0":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz#3aa30d2f0c81a8ac5995b6d94ed4eaa2c3055824"
@@ -270,7 +260,7 @@
     "@fastify/forwarded" "^3.0.0"
     ipaddr.js "^2.1.0"
 
-"@fastify/reply-from@^12.0.2":
+"@fastify/reply-from@12.1.0":
   version "12.1.0"
   resolved "https://registry.yarnpkg.com/@fastify/reply-from/-/reply-from-12.1.0.tgz#e376a2119e4465a84f399e6b2092454268ed1fdb"
   integrity sha512-5SvMj0NnAAhno/MIv+bErCfzYxcqTueqUxCyub/i+68/CqYWroYg0/p8D0ZhrSQcDigowaKk+MEQSoLjbGwZ+g==
@@ -6352,11 +6342,6 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
-
-ws@^8.18.0:
-  version "8.18.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.2.tgz#42738b2be57ced85f46154320aabb51ab003705a"
-  integrity sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
The `@fastify/http-proxy` plugin we were using was overly complex for our needs — it's designed to be used as a fully fledged proxy server for handling multiple routes with complex logic. It's ultimately built on `@fastify/reply-from`, which is a plugin for forwarding a single request/endpoint to an upstream server.

Really all we need is `@fastify/reply-from`, and this also gives us more control over the request handling — this will make it a lot easier to conditionally proxy the request or simply publish the event to pub/sub. It also allows us to take advantage of Fastify's built in request validation using JSON schema since we are now defining our route directory.