### PR TITLE
Revert "Refactored proxy endpoint to use `@fastify/reply-from` instead of `@fastify/http-proxy`"

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@fastify/cors": "11.0.1",
-    "@fastify/reply-from": "12.1.0",
+    "@fastify/http-proxy": "11.2.0",
     "@fastify/type-provider-typebox": "5.1.0",
     "@google-cloud/firestore": "7.11.1",
     "@google-cloud/pino-logging-gcp-config": "1.0.6",

--- a/src/plugins/proxy.ts
+++ b/src/plugins/proxy.ts
@@ -1,38 +1,47 @@
-import {FastifyInstance, FastifyReply as FastifyReplyBase} from 'fastify';
+import {FastifyInstance} from 'fastify';
 import fp from 'fastify-plugin';
-import {processRequest} from '../services/proxy';
-import {FastifyRequest, FastifyReply} from '../types';
-import {AnalyticsRouteSchema, ValidatedAnalyticsRequest} from '../schemas/v1/page-hit-raw-request';
+import fastifyHttpProxy, {FastifyHttpProxyOptions} from '@fastify/http-proxy';
+import {processRequest, validateRequestWithSchema} from '../services/proxy';
 
 async function proxyPlugin(fastify: FastifyInstance) {
-    await fastify.register(import('@fastify/reply-from'), {
+    // Register the analytics proxy using fastify-http-proxy with custom hooks
+    await fastify.register(fastifyHttpProxy, {
+        upstream: process.env.PROXY_TARGET || 'http://localhost:3000/local-proxy',
+        prefix: '/tb/web_analytics',
+        rewritePrefix: '', // Remove the prefix when forwarding
+        httpMethods: ['GET', 'POST', 'PUT', 'DELETE'],
+        preValidation: validateRequestWithSchema as FastifyHttpProxyOptions['preValidation'],
+        preHandler: processRequest as FastifyHttpProxyOptions['preHandler'],
+        replyOptions: {
+            onError: (reply, error) => {
+                // Log proxy errors with proper structure for GCP
+                const unwrappedError = 'error' in error ? error.error : error;
+                reply.log.error({
+                    err: {
+                        message: unwrappedError.message,
+                        stack: unwrappedError.stack,
+                        name: unwrappedError.name
+                    },
+                    httpRequest: {
+                        requestMethod: reply.request.method,
+                        requestUrl: reply.request.url,
+                        userAgent: reply.request.headers['user-agent'],
+                        remoteIp: reply.request.ip,
+                        referer: reply.request.headers.referer,
+                        protocol: `${reply.request.protocol.toUpperCase()}/${reply.request.raw.httpVersion}`,
+                        status: 502
+                    },
+                    upstream: process.env.PROXY_TARGET || 'http://localhost:3000/local-proxy',
+                    type: 'proxy_error'
+                }, 'Proxy error occurred');
+                reply.status(502).send({error: 'Proxy error'});
+            }
+        },
         disableRequestLogging: process.env.LOG_PROXY_REQUESTS === 'false'
     });
-
-    // Main analytics proxy route
-    fastify.post('/tb/web_analytics', {
-        schema: AnalyticsRouteSchema,
-        preHandler: async (request: ValidatedAnalyticsRequest, reply: FastifyReplyBase) => {
-            await processRequest(request as FastifyRequest, reply as FastifyReply);
-        }
-    }, async (request, reply) => {
-        try {
-            const targetUrl = process.env.PROXY_TARGET || 'http://localhost:3000/local-proxy';
-            const url = new URL(request.url, 'http://localhost');
-            await reply.from(targetUrl + url.search);
-        } catch (error) {
-            // Log proxy errors and let Fastify handle the response
-            request.log.error({
-                error: error instanceof Error ? error.message : String(error),
-                targetUrl: process.env.PROXY_TARGET || 'http://localhost:3000/local-proxy',
-                url: request.url
-            }, 'Proxy forwarding failed');
-            throw error; // Re-throw to let Fastify handle the error response
-        }
-    });
     
-    // Local proxy endpoint for development/testing
-    fastify.post('/local-proxy', async () => {
+    // Register local proxy endpoint for development/testing
+    fastify.post('/local-proxy*', async () => {
         return 'Hello World - From the local proxy';
     });
 }

--- a/src/schemas/v1/page-hit-raw-request.ts
+++ b/src/schemas/v1/page-hit-raw-request.ts
@@ -1,5 +1,4 @@
-import {Type, FormatRegistry, Static} from '@sinclair/typebox';
-import {FastifyRequest as FastifyRequestBase} from 'fastify';
+import {Type, FormatRegistry} from '@sinclair/typebox';
 import validator from '@tryghost/validator';
 
 // Register format validators for runtime validation using @tryghost/validator
@@ -84,17 +83,3 @@ export const PageHitRawRequestSchema = Type.Object({
     headers: HeadersSchema,
     body: BodySchema
 });
-
-// Fastify route schema configuration for analytics endpoints
-export const AnalyticsRouteSchema = {
-    querystring: QueryParamsSchema,
-    headers: HeadersSchema,
-    body: BodySchema
-};
-
-// TypeScript type for validated analytics requests
-export type ValidatedAnalyticsRequest = FastifyRequestBase<{
-    Querystring: Static<typeof QueryParamsSchema>;
-    Headers: Static<typeof HeadersSchema>;
-    Body: Static<typeof BodySchema>;
-}>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,6 +245,16 @@
   resolved "https://registry.yarnpkg.com/@fastify/forwarded/-/forwarded-3.0.0.tgz#0fc96cdbbb5a38ad453d2d5533a34f09b4949b37"
   integrity sha512-kJExsp4JCms7ipzg7SJ3y8DwmePaELHxKYtg+tZow+k0znUTf3cb+npgyqm8+ATZOdmfgfydIebPDWM172wfyA==
 
+"@fastify/http-proxy@11.2.0":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@fastify/http-proxy/-/http-proxy-11.2.0.tgz#d58122383ab59dcb78344e8a02fdf3ac2429730e"
+  integrity sha512-sHhAJEGnVefw3P4N/HDyo2lGagBwYUePXE8kXflKnNF+4vYxNItPMoNjETpIEYbuBeqoV7lHOgAKu0+y9K7SUA==
+  dependencies:
+    "@fastify/reply-from" "^12.0.2"
+    fast-querystring "^1.1.2"
+    fastify-plugin "^5.0.1"
+    ws "^8.18.0"
+
 "@fastify/merge-json-schemas@^0.2.0":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz#3aa30d2f0c81a8ac5995b6d94ed4eaa2c3055824"
@@ -260,7 +270,7 @@
     "@fastify/forwarded" "^3.0.0"
     ipaddr.js "^2.1.0"
 
-"@fastify/reply-from@12.1.0":
+"@fastify/reply-from@^12.0.2":
   version "12.1.0"
   resolved "https://registry.yarnpkg.com/@fastify/reply-from/-/reply-from-12.1.0.tgz#e376a2119e4465a84f399e6b2092454268ed1fdb"
   integrity sha512-5SvMj0NnAAhno/MIv+bErCfzYxcqTueqUxCyub/i+68/CqYWroYg0/p8D0ZhrSQcDigowaKk+MEQSoLjbGwZ+g==
@@ -6342,6 +6352,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@^8.18.0:
+  version "8.18.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.2.tgz#42738b2be57ced85f46154320aabb51ab003705a"
+  integrity sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
This reverts the refactor from http-proxy to reply-from. I think we should do this, but I don't have enough confidence in our e2e tests just yet to roll this out. I'll improve our tests using wiremock before making this change.

This reverts commit 8932b6161a0d9df6039f972df8af600757f266fe.