### PR TITLE
Added wiremock for e2e testing

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -60,12 +60,15 @@ services:
       - PUBSUB_EMULATOR_HOST=pubsub:8085
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
       - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
+      - PROXY_TARGET=http://fake-tinybird:8080/v0/events
     networks:
       - dev-network
     depends_on:
       firestore:
         condition: service_healthy
       pubsub:
+        condition: service_healthy
+      fake-tinybird:
         condition: service_healthy
 
   worker:
@@ -96,6 +99,19 @@ services:
         condition: service_healthy
       pubsub:
         condition: service_healthy
+
+  fake-tinybird:
+    image: wiremock/wiremock:3.9.1
+    ports:
+      - ${FAKE_TINYBIRD_PORT:-8089}:8080
+    command: ["--global-response-templating", "--verbose"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    networks:
+      - dev-network
 
   test:
     image: local/traffic-analytics:development

--- a/test/e2e/web_analytics.test.ts
+++ b/test/e2e/web_analytics.test.ts
@@ -106,9 +106,25 @@ describe('E2E /tb/web_analytics', () => {
 
         expect(tinybirdRequests).toHaveLength(1);
 
-        // Verify that the request was successfully forwarded to fake-tinybird
-        // (The body parsing can be enhanced later if needed)
-        expect(tinybirdRequests[0]).toBeTruthy();
+        // Verify the request body was processed and enriched  
+        const requestBody = wireMock.parseRequestBody(tinybirdRequests[0]);
+
+        expect(requestBody).toMatchObject({
+            timestamp: DEFAULT_BODY.timestamp,
+            action: 'page_hit',
+            version: '1',
+            // Should have session_id added by processing
+            session_id: expect.any(String),
+            payload: expect.objectContaining({
+                site_uuid: '940b73e9-4952-4752-b23d-9486f999c47e',
+                pathname: '/test-page',
+                href: 'https://example.com/test-page',
+                // Should have parsed user agent info
+                browser: expect.any(String),
+                os: expect.any(String),
+                device: expect.any(String)
+            })
+        });
     });
 
     describe('validation failures', () => {
@@ -220,8 +236,22 @@ describe('E2E /tb/web_analytics', () => {
 
         expect(tinybirdRequests).toHaveLength(1);
 
-        // Verify that the healthcheck request was successfully forwarded to fake-tinybird
-        // (The body parsing can be enhanced later if needed)
-        expect(tinybirdRequests[0]).toBeTruthy();
+        // Verify healthcheck request body was processed correctly
+        const requestBody = wireMock.parseRequestBody(tinybirdRequests[0]);
+        expect(requestBody).toMatchObject({
+            timestamp: healthcheckBody.timestamp,
+            action: 'page_hit',
+            version: '1',
+            // Should have session_id added by processing  
+            session_id: expect.any(String),
+            payload: expect.objectContaining({
+                site_uuid: 'c7929de8-27d7-404e-b714-0fc774f701e6',
+                location: null,
+                member_status: 'undefined',
+                // Should have parsed user agent info
+                browser: expect.any(String),
+                os: expect.any(String)
+            })
+        });
     });
 });

--- a/test/utils/wiremock.ts
+++ b/test/utils/wiremock.ts
@@ -1,0 +1,199 @@
+interface WireMockStubMapping {
+    id?: string;
+    request: {
+        method: string;
+        url?: string;
+        urlPattern?: string;
+        headers?: Record<string, any>;
+        bodyPatterns?: Array<{
+            equalToJson?: any;
+            matchesJsonPath?: string;
+            contains?: string;
+        }>;
+    };
+    response: {
+        status: number;
+        headers?: Record<string, string>;
+        body?: string;
+        jsonBody?: any;
+    };
+    priority?: number;
+}
+
+interface WireMockRequestLog {
+    id: string;
+    request: {
+        url: string;
+        absoluteUrl: string;
+        method: string;
+        clientIp: string;
+        headers: Record<string, string>;
+        body: string;
+        loggedDate: number;
+        loggedDateString: string;
+    };
+    responseDefinition: {
+        status: number;
+        body: string;
+    };
+    wasMatched: boolean;
+}
+
+export class WireMock {
+    private baseUrl: string;
+
+    constructor(baseUrl: string = 'http://localhost:8089') {
+        this.baseUrl = baseUrl;
+    }
+
+    async setupStub(mapping: WireMockStubMapping): Promise<void> {
+        const response = await fetch(`${this.baseUrl}/__admin/mappings`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(mapping)
+        });
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`Failed to setup WireMock stub: ${response.status} ${error}`);
+        }
+    }
+
+    async resetAll(): Promise<void> {
+        const response = await fetch(`${this.baseUrl}/__admin/reset`, {
+            method: 'POST'
+        });
+
+        if (!response.ok) {
+            throw new Error(`Failed to reset WireMock: ${response.status}`);
+        }
+    }
+
+    async getRequestLogs(): Promise<WireMockRequestLog[]> {
+        const response = await fetch(`${this.baseUrl}/__admin/requests`);
+        
+        if (!response.ok) {
+            throw new Error(`Failed to get request logs: ${response.status}`);
+        }
+
+        const data = await response.json();
+        return data.requests || [];
+    }
+
+    async findRequestsMatching(criteria: {
+        method?: string;
+        url?: string;
+        urlPattern?: string;
+        headers?: Record<string, string>;
+    }): Promise<WireMockRequestLog[]> {
+        const response = await fetch(`${this.baseUrl}/__admin/requests/find`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(criteria)
+        });
+
+        if (!response.ok) {
+            throw new Error(`Failed to find requests: ${response.status}`);
+        }
+
+        const data = await response.json();
+        return data.requests || [];
+    }
+
+    async waitForHealthy(timeoutMs: number = 30000): Promise<void> {
+        const start = Date.now();
+        
+        while (Date.now() - start < timeoutMs) {
+            try {
+                const response = await fetch(`${this.baseUrl}/__admin/health`);
+                if (response.ok) {
+                    return;
+                }
+            } catch (error) {
+                // Ignore connection errors and retry
+            }
+            
+            await new Promise<void>((resolve) => {
+                setTimeout(() => resolve(), 1000);
+            });
+        }
+        
+        throw new Error(`WireMock not ready after ${timeoutMs}ms`);
+    }
+
+    // Helper method to setup a simple stub for Tinybird analytics endpoint
+    async setupTinybirdStub(options: {
+        status?: number;
+        responseBody?: string;
+        responseHeaders?: Record<string, string>;
+    } = {}): Promise<void> {
+        const {
+            status = 200,
+            responseBody = 'OK',
+            responseHeaders = {'Content-Type': 'text/plain'}
+        } = options;
+
+        await this.setupStub({
+            request: {
+                method: 'POST',
+                urlPattern: '.*'
+            },
+            response: {
+                status,
+                body: responseBody,
+                headers: responseHeaders
+            },
+            priority: 1
+        });
+    }
+
+    // Helper method to verify that a request was made to Tinybird
+    async verifyTinybirdRequest(expectedData?: {
+        token?: string;
+        name?: string;
+        bodyContains?: string;
+    }): Promise<WireMockRequestLog[]> {
+        const criteria: any = {
+            method: 'POST'
+        };
+
+        const requests = await this.findRequestsMatching(criteria);
+
+        if (expectedData) {
+            return requests.filter((request) => {
+                let matches = true;
+
+                if (expectedData.token && request.request?.url) {
+                    matches = matches && request.request.url.includes(`token=${expectedData.token}`);
+                }
+
+                if (expectedData.name && request.request?.url) {
+                    matches = matches && request.request.url.includes(`name=${expectedData.name}`);
+                }
+
+                if (expectedData.bodyContains && request.request?.body) {
+                    matches = matches && request.request.body.includes(expectedData.bodyContains);
+                }
+
+                return matches;
+            });
+        }
+
+        return requests;
+    }
+
+    // Helper method to get the parsed JSON body from a request
+    parseRequestBody(request: WireMockRequestLog): any {
+        try {
+            return JSON.parse(request.request?.body || '{}');
+        } catch (error) {
+            return null;
+        }
+    }
+}
+
+export default WireMock;


### PR DESCRIPTION
Our current e2e tests we're not fully testing that we are sending the right data to Tinybird. This commit sets up wiremock in place of our `/local-proxy` endpoint, so we can not only check the response we get from our own fake endpoint, but also make assertions on the data we're sending to the `PROXY_TARGET`.