### PR TITLE
Added e2e tests to CI

### DIFF
--- a/.github/actions/lint-and-test/action.yml
+++ b/.github/actions/lint-and-test/action.yml
@@ -25,6 +25,19 @@ runs:
         export DOCKER_IMAGE=${{ inputs.docker-image }}
         docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm test
 
+    # E2E Test
+    - name: Start services for E2E tests
+      shell: bash
+      run: |
+        export DOCKER_IMAGE=${{ inputs.docker-image }}
+        docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml up -d
+        
+    - name: Run E2E tests
+      shell: bash
+      run: |
+        export DOCKER_IMAGE=${{ inputs.docker-image }}
+        docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm e2e-test
+
     # Copy coverage report from test container
     - name: Copy coverage report
       shell: bash

--- a/.github/actions/lint-and-test/compose.ci.yml
+++ b/.github/actions/lint-and-test/compose.ci.yml
@@ -44,3 +44,20 @@ services:
         condition: service_healthy
       pubsub:
         condition: service_healthy
+
+  # Override e2e-test service to use pre-built image and CI configuration
+  e2e-test:
+    image: ${DOCKER_IMAGE}
+    command: ["yarn", "test:e2e"]
+    environment:
+      - NODE_ENV=testing
+      - ANALYTICS_SERVICE_URL=http://analytics-service:3000
+      - WIREMOCK_URL=http://fake-tinybird:8080
+    networks:
+      - dev-network
+    profiles: []
+    depends_on:
+      analytics-service:
+        condition: service_started
+      fake-tinybird:
+        condition: service_healthy

--- a/compose.override.yml
+++ b/compose.override.yml
@@ -22,3 +22,8 @@ services:
     volumes:
       - .:/app
       - node_modules_volume:/app/node_modules
+
+  e2e-test:
+    volumes:
+      - .:/app
+      - node_modules_volume:/app/node_modules

--- a/compose.yml
+++ b/compose.yml
@@ -107,6 +107,27 @@ services:
     networks:
       - dev-network
 
+  e2e-test:
+    image: local/traffic-analytics:development
+    pull_policy: never
+    command: ["yarn", "test:e2e"]
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      - NODE_ENV=testing
+      - ANALYTICS_SERVICE_URL=http://analytics-service:3000
+      - WIREMOCK_URL=http://fake-tinybird:8080
+    tty: true
+    networks:
+      - dev-network
+    profiles: [e2e]
+    depends_on:
+      analytics-service:
+        condition: service_started
+      fake-tinybird:
+        condition: service_healthy
+
   test:
     image: local/traffic-analytics:development
     pull_policy: never

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "docker:test": "docker compose --profile testing run --rm test",
     "docker:test:unit": "docker compose --profile testing run --rm test yarn test:unit",
     "docker:test:integration": "docker compose --profile testing run --rm test yarn test:integration",
+    "docker:test:e2e": "docker compose run --rm e2e-test",
     "test:healthchecks": "playwright test",
     "lint": "eslint src/ test/ scripts/ *.ts --ext .js,.ts --cache",
     "lint:fix": "eslint src/ test/ scripts/ *.ts --ext .js,.ts --cache --fix",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "docker:lint": "docker compose --profile testing run --rm lint",
     "docker:ci:lint": "DOCKER_IMAGE=local/traffic-analytics:development docker compose -f compose.yml -f .github/actions/lint-and-test/compose.ci.yml run --rm lint",
     "docker:ci:test": "DOCKER_IMAGE=local/traffic-analytics:development docker compose -f compose.yml -f .github/actions/lint-and-test/compose.ci.yml run --rm test",
+    "docker:ci:test:e2e": "DOCKER_IMAGE=local/traffic-analytics:development docker compose -f compose.yml -f .github/actions/lint-and-test/compose.ci.yml run --rm e2e-test",
     "docker:ci:down": "DOCKER_IMAGE=local/traffic-analytics:development docker compose -f compose.yml -f .github/actions/lint-and-test/compose.ci.yml down",
     "ship": "node scripts/ship.js"
   },

--- a/test/e2e/web_analytics.test.ts
+++ b/test/e2e/web_analytics.test.ts
@@ -53,7 +53,7 @@ async function makeWebAnalyticsRequest(options: WebAnalyticsRequestOptions = {})
     // Build query string
     const queryString = new URLSearchParams(queryParams).toString();
     
-    const baseUrl = 'http://localhost:3000';
+    const baseUrl = process.env.ANALYTICS_SERVICE_URL || 'http://localhost:3000';
     const url = `${baseUrl}/tb/web_analytics?${queryString}`;
 
     return fetch(url, {
@@ -64,12 +64,11 @@ async function makeWebAnalyticsRequest(options: WebAnalyticsRequestOptions = {})
 }
 
 describe('E2E /tb/web_analytics', () => {
-    const wiremockUrl = 'http://localhost:8089';
-    const wireMock = new WireMock(wiremockUrl);
+    let wireMock: WireMock;
 
     beforeAll(async () => {
-        // Wait for WireMock to be ready
-        await wireMock.waitForHealthy();
+        const wiremockUrl = process.env.WIREMOCK_URL || 'http://localhost:8089';
+        wireMock = new WireMock(wiremockUrl);
         
         // Setup default stub for Tinybird endpoint
         await wireMock.setupTinybirdStub({
@@ -163,7 +162,7 @@ describe('E2E /tb/web_analytics', () => {
         it('should reject requests with missing required body fields', async () => {
             // Send incomplete body directly without merging with defaults
             const queryString = new URLSearchParams(DEFAULT_QUERY_PARAMS).toString();
-            const baseUrl = 'http://localhost:3000';
+            const baseUrl = process.env.ANALYTICS_SERVICE_URL || 'http://localhost:3000';
             const url = `${baseUrl}/tb/web_analytics?${queryString}`;
             
             const response = await fetch(url, {
@@ -211,7 +210,7 @@ describe('E2E /tb/web_analytics', () => {
         };
 
         const queryString = new URLSearchParams(DEFAULT_QUERY_PARAMS).toString();
-        const baseUrl = 'http://localhost:3000';
+        const baseUrl = process.env.ANALYTICS_SERVICE_URL || 'http://localhost:3000';
         const url = `${baseUrl}/tb/web_analytics?${queryString}`;
         
         const response = await fetch(url, {


### PR DESCRIPTION
Currently our e2e tests only run locally against the services running in docker compose. In CI, we don't ever install the node dependencies except in the Docker image itself, so in order to run the e2e tests in CI we'll need to modify the e2e tests to be able to run in docker compose. 

This adds a new e2e-test service to our `compose.yml` file and makes the required changes to the e2e test suite to be able to run in this environment. This way we can run the e2e tests locally with `docker compose run --rm e2e-test` (or `yarn docker:test:e2e`). It also paves the way to running these tests in CI.