### PR TITLE
Refactored compose files to improve parity between local and CI

### DIFF
--- a/.github/actions/lint-and-test/action.yml
+++ b/.github/actions/lint-and-test/action.yml
@@ -16,21 +16,21 @@ runs:
       shell: bash
       run: |
         export DOCKER_IMAGE=${{ inputs.docker-image }}
-        docker compose -f ${{ github.action_path }}/compose.ci.yml run --rm lint
+        docker compose -f ../../../compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm lint
 
     # Test with compose (includes Firestore emulator)
     - name: Test
       shell: bash
       run: |
         export DOCKER_IMAGE=${{ inputs.docker-image }}
-        docker compose -f ${{ github.action_path }}/compose.ci.yml run --rm test
+        docker compose -f ../../../compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm test
 
     # Copy coverage report from test container
     - name: Copy coverage report
       shell: bash
       run: |
         export DOCKER_IMAGE=${{ inputs.docker-image }}
-        CONTAINER_ID=$(docker compose -f ${{ github.action_path }}/compose.ci.yml ps -q test | head -1)
+        CONTAINER_ID=$(docker compose -f ../../../compose.yml -f ${{ github.action_path }}/compose.ci.yml ps -q test | head -1)
         if [ ! -z "$CONTAINER_ID" ]; then
           if docker cp $CONTAINER_ID:/app/coverage/cobertura-coverage.xml .; then
             echo "Coverage report copied successfully"
@@ -53,4 +53,4 @@ runs:
       if: always()
       run: |
         export DOCKER_IMAGE=${{ inputs.docker-image }}
-        docker compose -f ${{ github.action_path }}/compose.ci.yml down
+        docker compose -f ../../../compose.yml -f ${{ github.action_path }}/compose.ci.yml down

--- a/.github/actions/lint-and-test/action.yml
+++ b/.github/actions/lint-and-test/action.yml
@@ -16,21 +16,21 @@ runs:
       shell: bash
       run: |
         export DOCKER_IMAGE=${{ inputs.docker-image }}
-        docker compose -f ../../../compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm lint
+        docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm lint
 
     # Test with compose (includes Firestore emulator)
     - name: Test
       shell: bash
       run: |
         export DOCKER_IMAGE=${{ inputs.docker-image }}
-        docker compose -f ../../../compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm test
+        docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm test
 
     # Copy coverage report from test container
     - name: Copy coverage report
       shell: bash
       run: |
         export DOCKER_IMAGE=${{ inputs.docker-image }}
-        CONTAINER_ID=$(docker compose -f ../../../compose.yml -f ${{ github.action_path }}/compose.ci.yml ps -q test | head -1)
+        CONTAINER_ID=$(docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml ps -q test | head -1)
         if [ ! -z "$CONTAINER_ID" ]; then
           if docker cp $CONTAINER_ID:/app/coverage/cobertura-coverage.xml .; then
             echo "Coverage report copied successfully"
@@ -53,4 +53,4 @@ runs:
       if: always()
       run: |
         export DOCKER_IMAGE=${{ inputs.docker-image }}
-        docker compose -f ../../../compose.yml -f ${{ github.action_path }}/compose.ci.yml down
+        docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml down

--- a/.github/actions/lint-and-test/compose.ci.yml
+++ b/.github/actions/lint-and-test/compose.ci.yml
@@ -1,42 +1,28 @@
-name: traffic-analytics-ci
+# CI override that extends the base compose.yml
+# This removes volumes and bind mounts while using pre-built images
 
 services:
+  # Override emulator services to use CI-specific project name
   firestore:
-    image: google/cloud-sdk:emulators
-    command: ["gcloud", "emulators", "firestore", "start", "--host-port=0.0.0.0:8080"]
-    ports:
-      - 8080:8080
     environment:
       - GOOGLE_CLOUD_PROJECT=traffic-analytics-ci
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080"]
-      interval: 5s
-      timeout: 3s
-      retries: 5
 
   pubsub:
-    image: google/cloud-sdk:emulators
-    command: ["/app/start-pubsub.sh"]
-    ports:
-      - 8085:8085
-    volumes:
-      - ../../../docker/pubsub/start-pubsub.sh:/app/start-pubsub.sh:ro
     environment:
       - GOOGLE_CLOUD_PROJECT=traffic-analytics-ci
-      - PUBSUB_PORT=8085
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
-    healthcheck:
-      test: ["CMD", "sh", "-c", "curl -f http://localhost:8085 && test -f /tmp/pubsub-ready"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
+      - PUBSUB_SUBSCRIPTION_PAGE_HITS_RAW=traffic-analytics-page-hits-raw-sub
 
+  # Override lint service to use pre-built image
   lint:
     image: ${DOCKER_IMAGE}
-    command: ["yarn", "lint"]
     environment:
       - NODE_ENV=testing
+    networks:
+      - dev-network
+    profiles: []
 
+  # Override test service to use pre-built image and CI configuration
   test:
     image: ${DOCKER_IMAGE}
     command: ["yarn", "test"]
@@ -47,7 +33,12 @@ services:
       - PUBSUB_EMULATOR_HOST=pubsub:8085
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
       - PUBSUB_SUBSCRIPTION_PAGE_HITS_RAW=traffic-analytics-page-hits-raw-sub
+      - FIRESTORE_DATABASE_ID=(default)
+      - FIRESTORE_SALT_COLLECTION=salts
       - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
+    networks:
+      - dev-network
+    profiles: []
     depends_on:
       firestore:
         condition: service_healthy

--- a/compose.override.yml
+++ b/compose.override.yml
@@ -1,0 +1,24 @@
+# Local development overrides
+# This file is automatically loaded by `docker compose` for local development
+# It adds bind mounts and volumes that are needed for live code reloading
+
+services:
+  analytics-service:
+    volumes:
+      - .:/app
+      - node_modules_volume:/app/node_modules
+
+  worker:
+    volumes:
+      - .:/app
+      - node_modules_volume:/app/node_modules
+
+  test:
+    volumes:
+      - .:/app
+      - node_modules_volume:/app/node_modules
+
+  lint:
+    volumes:
+      - .:/app
+      - node_modules_volume:/app/node_modules

--- a/compose.yml
+++ b/compose.yml
@@ -47,9 +47,6 @@ services:
     command: ["yarn", "dev"]
     ports:
       - ${ANALYTICS_PORT:-3000}:3000
-    volumes:
-      - .:/app
-      - node_modules_volume:/app/node_modules
     env_file:
       - path: .env
         required: false
@@ -77,9 +74,6 @@ services:
     command: ["yarn", "dev"]
     ports:
       - ${WORKER_PORT:-3001}:3000
-    volumes:
-      - .:/app
-      - node_modules_volume:/app/node_modules
     env_file:
       - path: .env
         required: false
@@ -117,11 +111,9 @@ services:
     image: local/traffic-analytics:development
     pull_policy: never
     command: sh -c "yarn test && yarn lint"
-    volumes:
-      - .:/app
-      - node_modules_volume:/app/node_modules
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - NODE_ENV=testing
       - GOOGLE_CLOUD_PROJECT=traffic-analytics-test
@@ -146,11 +138,9 @@ services:
     image: local/traffic-analytics:development
     pull_policy: never
     command: ["yarn", "lint"]
-    volumes:
-      - .:/app
-      - node_modules_volume:/app/node_modules
     env_file:
-      - .env
+      - path: .env
+        required: false
     tty: true
     networks:
       - test-network

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "lint": "eslint src/ test/ scripts/ *.ts --ext .js,.ts --cache",
     "lint:fix": "eslint src/ test/ scripts/ *.ts --ext .js,.ts --cache --fix",
     "docker:lint": "docker compose --profile testing run --rm lint",
+    "docker:ci:lint": "DOCKER_IMAGE=local/traffic-analytics:development docker compose -f compose.yml -f .github/actions/lint-and-test/compose.ci.yml run --rm lint",
+    "docker:ci:test": "DOCKER_IMAGE=local/traffic-analytics:development docker compose -f compose.yml -f .github/actions/lint-and-test/compose.ci.yml run --rm test",
+    "docker:ci:down": "DOCKER_IMAGE=local/traffic-analytics:development docker compose -f compose.yml -f .github/actions/lint-and-test/compose.ci.yml down",
     "ship": "node scripts/ship.js"
   },
   "files": [


### PR DESCRIPTION
Currently our main `compose.yml` and our `compose.ci.yml` are two completely different files, which is a pain to maintain and can lead to drift between our local dev environment and our CI environment. This changes to using a base `compose.yml` for both environments, with a `compose.override.yml` for local development (to add bind mounts and volumes for local development) and a `compose.ci.yml` which only includes overrides for the CI environment.

This should help prevent issues where tests pass locally but not in CI, and make it easier to maintain these two environments, which are 99% shared configuration.