### PR TITLE
Added multi-stage build to reduce image size in production

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: What to tag the built image as
     required: true
     default: traffic-analytics:latest
+  target:
+    description: The build target (development or production)
+    required: false
+    default: development
 
 outputs:
   image-name:
@@ -25,5 +29,6 @@ runs:
       with:
         context: .
         tags: ${{ inputs.image-name }}
+        target: ${{ inputs.target }}
         build-args: |
           NODE_VERSION=${{ inputs.node-version }}

--- a/.github/actions/lint-and-test/action.yml
+++ b/.github/actions/lint-and-test/action.yml
@@ -18,14 +18,16 @@ runs:
     - name: Lint
       shell: bash
       run: |
-        export DOCKER_IMAGE=${{ inputs.development-image }}
+        export DOCKER_IMAGE_DEVELOPMENT=${{ inputs.development-image }}
+        export DOCKER_IMAGE_PRODUCTION=${{ inputs.production-image }}
         docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm lint
 
     # Test with compose (includes Firestore emulator)
     - name: Test
       shell: bash
       run: |
-        export DOCKER_IMAGE=${{ inputs.development-image }}
+        export DOCKER_IMAGE_DEVELOPMENT=${{ inputs.development-image }}
+        export DOCKER_IMAGE_PRODUCTION=${{ inputs.production-image }}
         docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm test
 
     # E2E Test - using production image for services, development image for test runner
@@ -47,7 +49,8 @@ runs:
     - name: Copy coverage report
       shell: bash
       run: |
-        export DOCKER_IMAGE=${{ inputs.development-image }}
+        export DOCKER_IMAGE_DEVELOPMENT=${{ inputs.development-image }}
+        export DOCKER_IMAGE_PRODUCTION=${{ inputs.production-image }}
         CONTAINER_ID=$(docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml ps -q test | head -1)
         if [ ! -z "$CONTAINER_ID" ]; then
           if docker cp $CONTAINER_ID:/app/coverage/cobertura-coverage.xml .; then

--- a/.github/actions/lint-and-test/action.yml
+++ b/.github/actions/lint-and-test/action.yml
@@ -63,7 +63,7 @@ runs:
     # Upload coverage reports
     - name: Upload coverage reports
       uses: codecov/codecov-action@v3
-      if: success()
+      if: success() && inputs.node-version == 20
       with:
         files: ./cobertura-coverage.xml
         fail_ci_if_error: false

--- a/.github/actions/lint-and-test/action.yml
+++ b/.github/actions/lint-and-test/action.yml
@@ -2,8 +2,11 @@ name: "Lint & Test"
 description: "Lint and test the codebase"
 
 inputs:
-  docker-image:
-    description: Which docker image to run linting and testing on
+  development-image:
+    description: Development docker image to use for linting and unit/integration testing
+    required: true
+  production-image:
+    description: Production docker image to use for E2E testing
     required: true
 
 runs:
@@ -15,34 +18,36 @@ runs:
     - name: Lint
       shell: bash
       run: |
-        export DOCKER_IMAGE=${{ inputs.docker-image }}
+        export DOCKER_IMAGE=${{ inputs.development-image }}
         docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm lint
 
     # Test with compose (includes Firestore emulator)
     - name: Test
       shell: bash
       run: |
-        export DOCKER_IMAGE=${{ inputs.docker-image }}
+        export DOCKER_IMAGE=${{ inputs.development-image }}
         docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm test
 
-    # E2E Test
+    # E2E Test - using production image for services, development image for test runner
     - name: Start services for E2E tests
       shell: bash
       run: |
-        export DOCKER_IMAGE=${{ inputs.docker-image }}
+        export DOCKER_IMAGE_DEVELOPMENT=${{ inputs.development-image }}
+        export DOCKER_IMAGE_PRODUCTION=${{ inputs.production-image }}
         docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml up -d
         
     - name: Run E2E tests
       shell: bash
       run: |
-        export DOCKER_IMAGE=${{ inputs.docker-image }}
+        export DOCKER_IMAGE_DEVELOPMENT=${{ inputs.development-image }}
+        export DOCKER_IMAGE_PRODUCTION=${{ inputs.production-image }}
         docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm e2e-test
 
     # Copy coverage report from test container
     - name: Copy coverage report
       shell: bash
       run: |
-        export DOCKER_IMAGE=${{ inputs.docker-image }}
+        export DOCKER_IMAGE=${{ inputs.development-image }}
         CONTAINER_ID=$(docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml ps -q test | head -1)
         if [ ! -z "$CONTAINER_ID" ]; then
           if docker cp $CONTAINER_ID:/app/coverage/cobertura-coverage.xml .; then
@@ -55,7 +60,7 @@ runs:
     # Upload coverage reports
     - name: Upload coverage reports
       uses: codecov/codecov-action@v3
-      if: success() && inputs.node-version == 20
+      if: success()
       with:
         files: ./cobertura-coverage.xml
         fail_ci_if_error: false
@@ -65,5 +70,6 @@ runs:
       shell: bash
       if: always()
       run: |
-        export DOCKER_IMAGE=${{ inputs.docker-image }}
+        export DOCKER_IMAGE_DEVELOPMENT=${{ inputs.development-image }}
+        export DOCKER_IMAGE_PRODUCTION=${{ inputs.production-image }}
         docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml down

--- a/.github/actions/lint-and-test/compose.ci.yml
+++ b/.github/actions/lint-and-test/compose.ci.yml
@@ -16,6 +16,7 @@ services:
   # Override lint service to use pre-built development image
   lint:
     image: ${DOCKER_IMAGE_DEVELOPMENT}
+    build: null
     environment:
       - NODE_ENV=testing
     networks:
@@ -25,6 +26,7 @@ services:
   # Override test service to use pre-built development image and CI configuration
   test:
     image: ${DOCKER_IMAGE_DEVELOPMENT}
+    build: null
     command: ["yarn", "test"]
     environment:
       - NODE_ENV=testing
@@ -48,6 +50,8 @@ services:
   # Override analytics-service to use production image for E2E tests
   analytics-service:
     image: ${DOCKER_IMAGE_PRODUCTION}
+    build: null
+    command: ["yarn", "start"]
     environment:
       - NODE_ENV=production
       - GOOGLE_CLOUD_PROJECT=traffic-analytics-ci
@@ -69,6 +73,7 @@ services:
   # Override e2e-test service to use development image (needs vitest) but test against production services
   e2e-test:
     image: ${DOCKER_IMAGE_DEVELOPMENT}
+    build: null
     command: ["yarn", "test:e2e"]
     environment:
       - NODE_ENV=testing

--- a/.github/actions/lint-and-test/compose.ci.yml
+++ b/.github/actions/lint-and-test/compose.ci.yml
@@ -45,9 +45,21 @@ services:
       pubsub:
         condition: service_healthy
 
-  # Override e2e-test service to use pre-built image and CI configuration
+  # Override analytics-service to use production image for E2E tests
+  analytics-service:
+    image: ${DOCKER_IMAGE_PRODUCTION}
+    environment:
+      - NODE_ENV=production
+      - GOOGLE_CLOUD_PROJECT=traffic-analytics-ci
+      - FIRESTORE_EMULATOR_HOST=firestore:8080
+      - PUBSUB_EMULATOR_HOST=pubsub:8085
+      - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
+      - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
+      - PROXY_TARGET=http://fake-tinybird:8080/v0/events
+
+  # Override e2e-test service to use development image (needs vitest) but test against production services
   e2e-test:
-    image: ${DOCKER_IMAGE}
+    image: ${DOCKER_IMAGE_DEVELOPMENT}
     command: ["yarn", "test:e2e"]
     environment:
       - NODE_ENV=testing

--- a/.github/actions/lint-and-test/compose.ci.yml
+++ b/.github/actions/lint-and-test/compose.ci.yml
@@ -13,18 +13,18 @@ services:
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
       - PUBSUB_SUBSCRIPTION_PAGE_HITS_RAW=traffic-analytics-page-hits-raw-sub
 
-  # Override lint service to use pre-built image
+  # Override lint service to use pre-built development image
   lint:
-    image: ${DOCKER_IMAGE}
+    image: ${DOCKER_IMAGE_DEVELOPMENT}
     environment:
       - NODE_ENV=testing
     networks:
       - dev-network
     profiles: []
 
-  # Override test service to use pre-built image and CI configuration
+  # Override test service to use pre-built development image and CI configuration
   test:
-    image: ${DOCKER_IMAGE}
+    image: ${DOCKER_IMAGE_DEVELOPMENT}
     command: ["yarn", "test"]
     environment:
       - NODE_ENV=testing
@@ -56,6 +56,15 @@ services:
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
       - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
       - PROXY_TARGET=http://fake-tinybird:8080/v0/events
+    networks:
+      - dev-network
+    depends_on:
+      firestore:
+        condition: service_healthy
+      pubsub:
+        condition: service_healthy
+      fake-tinybird:
+        condition: service_healthy
 
   # Override e2e-test service to use development image (needs vitest) but test against production services
   e2e-test:

--- a/.github/actions/lint-and-test/compose.ci.yml
+++ b/.github/actions/lint-and-test/compose.ci.yml
@@ -70,6 +70,28 @@ services:
       fake-tinybird:
         condition: service_healthy
 
+  # Override worker service to use production image for E2E tests
+  worker:
+    image: ${DOCKER_IMAGE_PRODUCTION}
+    build: null
+    command: ["yarn", "start"]
+    environment:
+      - NODE_ENV=production
+      - WORKER_MODE=true
+      - GOOGLE_CLOUD_PROJECT=traffic-analytics-ci
+      - FIRESTORE_EMULATOR_HOST=firestore:8080
+      - PUBSUB_EMULATOR_HOST=pubsub:8085
+      - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
+      - PUBSUB_SUBSCRIPTION_PAGE_HITS_RAW=traffic-analytics-page-hits-raw-sub
+      - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
+    networks:
+      - dev-network
+    depends_on:
+      firestore:
+        condition: service_healthy
+      pubsub:
+        condition: service_healthy
+
   # Override e2e-test service to use development image (needs vitest) but test against production services
   e2e-test:
     image: ${DOCKER_IMAGE_DEVELOPMENT}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,16 +28,27 @@ jobs:
         id: extract-node-version
         uses: ./.github/actions/extract-node-version
 
-      - name: Build Docker Image
-        id: docker-build
+      - name: Build Development Docker Image
+        id: docker-build-dev
         uses: ./.github/actions/docker-build
         with:
           node-version: ${{ fromJSON(steps.extract-node-version.outputs.node-version) }}
+          image-name: local/traffic-analytics:development
+          target: development
+
+      - name: Build Production Docker Image
+        id: docker-build-prod
+        uses: ./.github/actions/docker-build
+        with:
+          node-version: ${{ fromJSON(steps.extract-node-version.outputs.node-version) }}
+          image-name: local/traffic-analytics:production
+          target: production
 
       - name: Lint & Test
         uses: ./.github/actions/lint-and-test
         with:
-          docker-image: ${{ steps.docker-build.outputs.image-name }}
+          development-image: ${{ steps.docker-build-dev.outputs.image-name }}
+          production-image: ${{ steps.docker-build-prod.outputs.image-name }}
 
       - name: "Auth with Google Cloud"
         id: gcp-auth
@@ -72,7 +83,7 @@ jobs:
         run: |
           for tag in $(echo "${{ steps.traffic-analytics-docker-metadata.outputs.tags }}"); do
             echo "Tagging: $tag"
-            docker tag ${{ steps.docker-build.outputs.image-name }} $tag
+            docker tag ${{ steps.docker-build-prod.outputs.image-name }} $tag
           done
 
           for tag in $(echo "${{ steps.traffic-analytics-docker-metadata.outputs.tags }}"); do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,22 @@ jobs:
         node: [20, 22]
     steps:
       - uses: actions/checkout@v4
-      - name: Build Docker Image
-        id: docker-build
+      - name: Build Development Docker Image
+        id: docker-build-dev
         uses: ./.github/actions/docker-build
         with:
           node-version: ${{ matrix.node }}
-          image-name: traffic-analytics-${{ matrix.node }}:latest
+          image-name: traffic-analytics-${{ matrix.node }}:development
+          target: development
+      - name: Build Production Docker Image
+        id: docker-build-prod
+        uses: ./.github/actions/docker-build
+        with:
+          node-version: ${{ matrix.node }}
+          image-name: traffic-analytics-${{ matrix.node }}:production
+          target: production
       - name: Lint & Test
         uses: ./.github/actions/lint-and-test
         with:
-          docker-image: ${{ steps.docker-build.outputs.image-name }}
+          development-image: ${{ steps.docker-build-dev.outputs.image-name }}
+          production-image: ${{ steps.docker-build-prod.outputs.image-name }}

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -19,16 +19,27 @@ jobs:
         id: extract-node-version
         uses: ./.github/actions/extract-node-version
 
-      - name: Build Docker Image
-        id: docker-build
+      - name: Build Development Docker Image
+        id: docker-build-dev
         uses: ./.github/actions/docker-build
         with:
           node-version: ${{ fromJSON(steps.extract-node-version.outputs.node-version) }}
+          image-name: local/traffic-analytics:development
+          target: development
+
+      - name: Build Production Docker Image
+        id: docker-build-prod
+        uses: ./.github/actions/docker-build
+        with:
+          node-version: ${{ fromJSON(steps.extract-node-version.outputs.node-version) }}
+          image-name: local/traffic-analytics:production
+          target: production
 
       - name: Lint & Test
         uses: ./.github/actions/lint-and-test
         with:
-          docker-image: ${{ steps.docker-build.outputs.image-name }}
+          development-image: ${{ steps.docker-build-dev.outputs.image-name }}
+          production-image: ${{ steps.docker-build-prod.outputs.image-name }}
 
       - name: "Login to Docker Hub"
         uses: docker/login-action@v3
@@ -54,7 +65,7 @@ jobs:
         run: |
           for tag in $(echo "${{ steps.traffic-analytics-docker-metadata.outputs.tags }}"); do
             echo "Tagging: $tag"
-            docker tag ${{ steps.docker-build.outputs.image-name }} $tag
+            docker tag ${{ steps.docker-build-prod.outputs.image-name }} $tag
           done
 
           for tag in $(echo "${{ steps.traffic-analytics-docker-metadata.outputs.tags }}"); do

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,32 @@
 ARG NODE_VERSION=22
 
+# Base stage with common Node.js setup
 FROM node:${NODE_VERSION}-alpine AS base
-
 WORKDIR /app
+RUN apk add --no-cache dumb-init
+ENTRYPOINT ["dumb-init", "--"]
 
+# Dependencies stage - install all dependencies (dev + prod)
+FROM base AS dependencies
 COPY package.json yarn.lock ./
-
 RUN yarn install --frozen-lockfile
 
+# Build stage - compile TypeScript
+FROM dependencies AS build
 COPY . .
-
 RUN yarn build
 
+# Development target - includes all dependencies for testing/linting
+FROM dependencies AS development
+COPY . .
+RUN yarn build
+CMD ["yarn", "dev"]
+
+# Production target - only runtime dependencies and built code
+FROM base AS production
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile --production && yarn cache clean
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/server.ts ./
+USER node
 CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,5 @@ FROM base AS production
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile --production && yarn cache clean
 COPY --from=build /app/dist ./dist
-COPY --from=build /app/server.ts ./
 USER node
 CMD ["yarn", "start"]

--- a/compose.yml
+++ b/compose.yml
@@ -44,6 +44,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: development
     command: ["yarn", "dev"]
     ports:
       - ${ANALYTICS_PORT:-3000}:3000
@@ -71,6 +72,10 @@ services:
   worker:
     image: local/traffic-analytics:development
     pull_policy: never
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
     command: ["yarn", "dev"]
     ports:
       - ${WORKER_PORT:-3001}:3000
@@ -110,6 +115,10 @@ services:
   e2e-test:
     image: local/traffic-analytics:development
     pull_policy: never
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
     command: ["yarn", "test:e2e"]
     env_file:
       - path: .env
@@ -131,6 +140,10 @@ services:
   test:
     image: local/traffic-analytics:development
     pull_policy: never
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
     command: sh -c "yarn test && yarn lint"
     env_file:
       - path: .env
@@ -158,6 +171,10 @@ services:
   lint:
     image: local/traffic-analytics:development
     pull_policy: never
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
     command: ["yarn", "lint"]
     env_file:
       - path: .env


### PR DESCRIPTION
We're currently seeing a fair number of errors in GCP Cloud Run:

`The request was aborted because there was no available instance. Additional troubleshooting documentation can be found at: https://cloud.google.com/run/docs/troubleshooting#abort-request`

We can also see that our container startup time is upwards of 10 seconds, which makes the service generally less capable of responding to bursts of requests. It seems that when the container takes more than 10 seconds to start, requests will be aborted. 

This commit aims to significantly reduce the size of our image by only bundling the production dependencies. This is something that we'd had setup initially and in hindsight should have kept around — at the time, it was only saving us a couple megabytes so the extra complexity wasn't justified, but now that our image has grown significantly, it makes a lot more sense to split the build into a development and production image.

This commit adds multi-stage builds to our Dockerfile, so we can target `development` or `production`. It updates our CI pipeline to use the development builds for running unit & integration tests, which require the development dependencies to run. Then it runs our e2e tests against the production image, to ensure that the core functionality of receiving requests and forwarding them to Tinybird is functional.

 | Image Type | Size   | Description|
 |---------------------------|--------|--------------------------------------------------|
 | Original (single-stage)   | 1.16GB | Includes all dev dependencies|
 | Development (multi-stage) | 1.16GB | Same as original - includes all deps for testing |
 | Production (multi-stage)  | 247MB  | Optimized - only runtime dependencies            |