### PR TITLE
Fixed flaky e2e tests in CI

### DIFF
--- a/.github/actions/lint-and-test/action.yml
+++ b/.github/actions/lint-and-test/action.yml
@@ -25,6 +25,12 @@ runs:
         export DOCKER_IMAGE=${{ inputs.docker-image }}
         docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm test
 
+    - name: Stop services
+      shell: bash
+      run: |
+        export DOCKER_IMAGE=${{ inputs.docker-image }}
+        docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml down
+
     # E2E Test
     - name: Start services for E2E tests
       shell: bash

--- a/.github/actions/lint-and-test/compose.ci.yml
+++ b/.github/actions/lint-and-test/compose.ci.yml
@@ -24,19 +24,15 @@ services:
 
   analytics-service:
     image: ${DOCKER_IMAGE}
+    build: {}  # Disable build in CI
     environment:
-      - NODE_ENV=testing
-    networks:
-      - dev-network
-    profiles: []
+      - GOOGLE_CLOUD_PROJECT=traffic-analytics-ci
 
   worker:
     image: ${DOCKER_IMAGE}
+    build: {}  # Disable build in CI
     environment:
-      - NODE_ENV=testing
-    networks:
-      - dev-network
-    profiles: []
+      - GOOGLE_CLOUD_PROJECT=traffic-analytics-ci
 
   # Override test service to use pre-built image and CI configuration
   test:

--- a/.github/actions/lint-and-test/compose.ci.yml
+++ b/.github/actions/lint-and-test/compose.ci.yml
@@ -68,8 +68,3 @@ services:
     networks:
       - dev-network
     profiles: []
-    depends_on:
-      analytics-service:
-        condition: service_started
-      fake-tinybird:
-        condition: service_healthy

--- a/.github/actions/lint-and-test/compose.ci.yml
+++ b/.github/actions/lint-and-test/compose.ci.yml
@@ -22,6 +22,22 @@ services:
       - dev-network
     profiles: []
 
+  analytics-service:
+    image: ${DOCKER_IMAGE}
+    environment:
+      - NODE_ENV=testing
+    networks:
+      - dev-network
+    profiles: []
+
+  worker:
+    image: ${DOCKER_IMAGE}
+    environment:
+      - NODE_ENV=testing
+    networks:
+      - dev-network
+    profiles: []
+
   # Override test service to use pre-built image and CI configuration
   test:
     image: ${DOCKER_IMAGE}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ ARG NODE_VERSION=22
 
 FROM node:${NODE_VERSION}-alpine AS base
 
+# Install curl for healthcheck
+RUN apk add --no-cache curl
+
 WORKDIR /app
 
 COPY package.json yarn.lock ./

--- a/compose.yml
+++ b/compose.yml
@@ -60,6 +60,12 @@ services:
       - PROXY_TARGET=http://fake-tinybird:8080/v0/events
     networks:
       - dev-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
     depends_on:
       firestore:
         condition: service_healthy
@@ -88,10 +94,18 @@ services:
       - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
     networks:
       - dev-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
     depends_on:
       firestore:
         condition: service_healthy
       pubsub:
+        condition: service_healthy
+      fake-tinybird:
         condition: service_healthy
 
   fake-tinybird:
@@ -124,7 +138,9 @@ services:
     profiles: [e2e]
     depends_on:
       analytics-service:
-        condition: service_started
+        condition: service_healthy
+      worker:
+        condition: service_healthy
       fake-tinybird:
         condition: service_healthy
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:unit:watch": "NODE_ENV=testing vitest watch test/unit",
     "test:integration": "NODE_ENV=testing vitest run --config vitest.config.integration.ts",
     "test:integration:watch": "NODE_ENV=testing vitest watch --config vitest.config.integration.ts",
-    "test:e2e": "NODE_ENV=testing vitest run test/e2e",
+    "test:e2e": "NODE_ENV=testing vitest run test/e2e --coverage=false",
     "test:types": "tsc --noEmit",
     "test": "yarn test:types && yarn test:unit && yarn test:integration",
     "docker:test": "docker compose --profile testing run --rm test",


### PR DESCRIPTION
The e2e tests were a bit flaky in CI — the e2e-test service was running before the analytics-service was fully healthy. This commit adds a healthcheck to the analytics-service and the worker, and force the e2e-test service to wait for both services to be healthy before running.