### PR TITLE
Improved logging for "Failed to generate user signature" message

### DIFF
--- a/src/services/proxy/processors/user-signature.ts
+++ b/src/services/proxy/processors/user-signature.ts
@@ -41,7 +41,7 @@ export async function generateUserSignature(request: FastifyRequest): Promise<vo
         request.body.session_id = userSignature;
     } catch (error) {
         // Log error and re-throw to fail the request
-        request.log.error('Failed to generate user signature:', error);
+        request.log.error({error}, 'Failed to generate user signature');
         throw error;
     }
 }

--- a/test/unit/services/proxy/processors/user-signature.test.ts
+++ b/test/unit/services/proxy/processors/user-signature.test.ts
@@ -113,7 +113,7 @@ describe('User Signature Processor', () => {
 
         await expect(generateUserSignature(request)).rejects.toThrow('Test error');
 
-        expect(request.log.error).toHaveBeenCalledWith('Failed to generate user signature:', error);
+        expect(request.log.error).toHaveBeenCalledWith({error}, 'Failed to generate user signature');
     });
 
     it('should throw error if body is missing', async () => {


### PR DESCRIPTION
We've seen a growing number of "Failed to generate user signature" log messages, but they don't include the full error because this log was formed incorrectly. This should fix the logging so we can see the full error message when generating the user-signature fails.