### PR TITLE
Created batch worker class and added message validation

### DIFF
--- a/scripts/send-test-request.sh
+++ b/scripts/send-test-request.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Test script to send a request matching the incoming-event-request schema
+# Usage: ./scripts/send-test-request.sh [URL] [TOKEN]
+
+# Default values
+URL="${1:-http://localhost:3000}"
+TOKEN="${2:-test-token-123}"
+
+# Generate UUIDs for the request
+SITE_UUID="12345678-1234-1234-1234-123456789abc"
+POST_UUID="87654321-4321-4321-4321-cba987654321"
+MEMBER_UUID="11111111-2222-3333-4444-555555555555"
+
+# Current timestamp in ISO8601 format
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+
+echo "Sending request to: ${URL}/tb/web_analytics"
+echo "Using token: ${TOKEN}"
+echo "Timestamp: ${TIMESTAMP}"
+echo ""
+
+curl -X POST "${URL}/tb/web_analytics?token=${TOKEN}&name=analytics_events" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36" \
+  -H "X-Site-UUID: ${SITE_UUID}" \
+  -H "Referer: https://example.com/previous-page" \
+  -d "{
+    \"timestamp\": \"${TIMESTAMP}\",
+    \"action\": \"page_hit\",
+    \"version\": \"1\",
+    \"session_id\": \"session-abc123\",
+    \"payload\": {
+      \"user-agent\": \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36\",
+      \"locale\": \"en-US\",
+      \"location\": \"San Francisco, CA\",
+      \"referrer\": \"https://google.com/search?q=example\",
+      \"pathname\": \"/blog/test-article\",
+      \"href\": \"https://example.com/blog/test-article\",
+      \"site_uuid\": \"${SITE_UUID}\",
+      \"post_uuid\": \"${POST_UUID}\",
+      \"post_type\": \"post\",
+      \"member_uuid\": \"${MEMBER_UUID}\",
+      \"member_status\": \"paid\"
+    }
+  }" \
+  -w "\n\nResponse Status: %{http_code}\nResponse Time: %{time_total}s\n" \
+  -v

--- a/src/services/batch-worker/BatchWorker.ts
+++ b/src/services/batch-worker/BatchWorker.ts
@@ -1,0 +1,42 @@
+import {Message} from '@google-cloud/pubsub';
+import {EventSubscriber} from '../events/subscriber';
+import {PageHitRawSchema} from '../../schemas/v1/page-hit-raw';
+import {Value} from '@sinclair/typebox/value';
+import logger from '../../utils/logger';
+
+class BatchWorker {
+    private topic: string;
+    private subscriber: EventSubscriber;
+
+    constructor(topic: string) {
+        logger.info('Creating batch worker for topic: %s', topic);
+        this.topic = topic;
+        this.subscriber = new EventSubscriber(topic);
+    }
+
+    public async start() {
+        logger.info('Starting batch worker for topic: %s', this.topic);
+        this.subscriber.subscribe(this.handleMessage);
+    }
+
+    public async stop() {
+        logger.info('Stopping batch worker for topic: %s', this.topic);
+        await this.subscriber.close();
+    }
+
+    private async handleMessage(message: Message) {
+        const messageData = message.data.toString();
+        try {
+            const json = JSON.parse(messageData);
+            const pageHitRaw = Value.Parse(PageHitRawSchema, json);
+            logger.info({pageHitRaw}, 'Worker received valid message');
+            message.ack();
+        } catch (error) {
+            logger.error({messageData, error}, 'Worker received invalid message');
+            message.nack();
+            throw error;
+        }
+    }
+}
+
+export default BatchWorker;

--- a/test/unit/services/batch-worker/batch-worker.test.ts
+++ b/test/unit/services/batch-worker/batch-worker.test.ts
@@ -1,0 +1,213 @@
+import {describe, it, expect, beforeEach, vi, afterEach} from 'vitest';
+import {Message} from '@google-cloud/pubsub';
+import BatchWorker from '../../../../src/services/batch-worker/BatchWorker';
+import {EventSubscriber} from '../../../../src/services/events/subscriber';
+import logger from '../../../../src/utils/logger';
+
+// Mock EventSubscriber
+vi.mock('../../../../src/services/events/subscriber', () => ({
+    EventSubscriber: vi.fn().mockImplementation(() => ({
+        subscribe: vi.fn(),
+        close: vi.fn()
+    }))
+}));
+
+const createMockMessage = (data: string) => {
+    return {
+        data: Buffer.from(data),
+        ack: vi.fn(),
+        nack: vi.fn()
+    } as unknown as Message;
+};
+
+describe('BatchWorker', () => {
+    let batchWorker: BatchWorker;
+    let mockSubscriber: EventSubscriber;
+    const testTopic = 'test-topic';
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Mock logger methods to avoid noise in tests
+        vi.spyOn(logger, 'info').mockImplementation(() => {});
+        vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+        batchWorker = new BatchWorker(testTopic);
+        mockSubscriber = (batchWorker as any).subscriber;
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('constructor', () => {
+        it('should create an instance with the provided topic', () => {
+            expect(batchWorker).toBeInstanceOf(BatchWorker);
+            expect(EventSubscriber).toHaveBeenCalledWith(testTopic);
+            expect(logger.info).toHaveBeenCalledWith('Creating batch worker for topic: %s', testTopic);
+        });
+    });
+
+    describe('start', () => {
+        it('should start the subscriber with handleMessage callback', async () => {
+            await batchWorker.start();
+
+            expect(logger.info).toHaveBeenCalledWith('Starting batch worker for topic: %s', testTopic);
+            expect(mockSubscriber.subscribe).toHaveBeenCalledWith(expect.any(Function));
+        });
+    });
+
+    describe('stop', () => {
+        it('should stop the subscriber', async () => {
+            await batchWorker.stop();
+
+            expect(logger.info).toHaveBeenCalledWith('Stopping batch worker for topic: %s', testTopic);
+            expect(mockSubscriber.close).toHaveBeenCalled();
+        });
+    });
+
+    describe('handleMessage', () => {
+        const validPageHitRawData = {
+            timestamp: '2024-01-01T12:00:00.000Z',
+            action: 'page_hit',
+            version: '1',
+            site_uuid: '550e8400-e29b-41d4-a716-446655440000',
+            payload: {
+                member_uuid: 'undefined',
+                member_status: 'undefined',
+                post_uuid: 'undefined',
+                post_type: 'null',
+                locale: 'en-US',
+                location: 'New York',
+                referrer: 'https://example.com',
+                pathname: '/blog/post',
+                href: 'https://mysite.com/blog/post'
+            },
+            meta: {
+                ip: '192.168.1.1',
+                'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
+            }
+        };
+        const expectMessageAcked = (message: Message) => {
+            expect(message.ack).toHaveBeenCalled();
+            expect(message.nack).not.toHaveBeenCalled();
+        };
+
+        const expectMessageNacked = (message: Message) => {
+            expect(message.nack).toHaveBeenCalled();
+            expect(message.ack).not.toHaveBeenCalled();
+        };
+
+        it('should process valid message and ack', async () => {
+            const mockMessage = createMockMessage(JSON.stringify(validPageHitRawData));
+
+            await (batchWorker as any).handleMessage(mockMessage);
+
+            expectMessageAcked(mockMessage);
+        });
+
+        it('should handle invalid JSON and nack message', async () => {
+            const invalidJson = 'invalid json';
+            const mockMessage = createMockMessage(invalidJson);
+
+            await expect((batchWorker as any).handleMessage(mockMessage)).rejects.toThrow();
+
+            expectMessageNacked(mockMessage);
+        });
+
+        it('should handle invalid schema and nack message', async () => {
+            const invalidData = {
+                timestamp: 'invalid-timestamp',
+                action: 'invalid-action',
+                version: '2'
+            };
+            const mockMessage = createMockMessage(JSON.stringify(invalidData));
+
+            await expect((batchWorker as any).handleMessage(mockMessage)).rejects.toThrow();
+
+            expectMessageNacked(mockMessage);
+        });
+
+        it('should handle missing required fields and nack message', async () => {
+            const incompleteData = {
+                timestamp: '2024-01-01T12:00:00.000Z',
+                action: 'page_hit'
+                // Missing required fields
+            };
+            const mockMessage = createMockMessage(JSON.stringify(incompleteData));
+
+            await expect((batchWorker as any).handleMessage(mockMessage)).rejects.toThrow();
+
+            expectMessageNacked(mockMessage);
+        });
+
+        it('should handle empty message data', async () => {
+            const mockMessage = createMockMessage('');
+
+            await expect((batchWorker as any).handleMessage(mockMessage)).rejects.toThrow();
+
+            expectMessageNacked(mockMessage);
+        });
+
+        it('should handle valid message with null values in payload', async () => {
+            const dataWithNulls = {
+                ...validPageHitRawData,
+                payload: {
+                    ...validPageHitRawData.payload,
+                    location: null,
+                    referrer: null
+                }
+            };
+            const mockMessage = createMockMessage(JSON.stringify(dataWithNulls));
+
+            await (batchWorker as any).handleMessage(mockMessage);
+
+            expectMessageAcked(mockMessage);
+        });
+
+        it('should handle valid message with different post types', async () => {
+            const testCases = ['null', 'post', 'page'];
+            
+            for (const postType of testCases) {
+                const dataWithPostType = {
+                    ...validPageHitRawData,
+                    payload: {
+                        ...validPageHitRawData.payload,
+                        post_type: postType
+                    }
+                };
+                const mockMessage = createMockMessage(JSON.stringify(dataWithPostType));
+
+                await (batchWorker as any).handleMessage(mockMessage);
+
+                expectMessageAcked(mockMessage);
+            }
+        });
+
+        it('should handle invalid UUID formats', async () => {
+            const invalidUuidData = {
+                ...validPageHitRawData,
+                site_uuid: 'invalid-uuid'
+            };
+            const mockMessage = createMockMessage(JSON.stringify(invalidUuidData));
+
+            await expect((batchWorker as any).handleMessage(mockMessage)).rejects.toThrow();
+
+            expectMessageNacked(mockMessage);
+        });
+
+        it('should handle invalid URL format in href', async () => {
+            const invalidUrlData = {
+                ...validPageHitRawData,
+                payload: {
+                    ...validPageHitRawData.payload,
+                    href: 'not-a-url'
+                }
+            };
+            const mockMessage = createMockMessage(JSON.stringify(invalidUrlData));
+
+            await expect((batchWorker as any).handleMessage(mockMessage)).rejects.toThrow();
+
+            expectMessageNacked(mockMessage);
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-661/analytics-service-should-batch-events-when-sending-to-tinybird

For simplify testing, this pulls out the BatchWorker functionality from the Fastify worker-plugin. The worker-plugin now just handles creating, starting and stopping the BatchWorker, so we can test the BatchWorker itself easily in isolation. 

It also adds message validation with simple logging for now to indicate if the message was valid or not. They should _all_ be valid since we're validating them before publishing them, but it doesn't hurt to doublecheck.