### PR TITLE
Improved logging for FirestoreSaltStore health check failures

### DIFF
--- a/src/services/salt-store/FirestoreSaltStore.ts
+++ b/src/services/salt-store/FirestoreSaltStore.ts
@@ -44,7 +44,7 @@ export class FirestoreSaltStore implements ISaltStore {
             await this.firestore.collection(this.collectionName).limit(1).get();
         } catch (error) {
             // Log warning but don't throw - allow graceful degradation
-            logger.warn('FirestoreSaltStore health check failed:', error instanceof Error ? error.message : error);
+            logger.warn({error}, 'FirestoreSaltStore health check failed');
         }
     }
 


### PR DESCRIPTION
This health check has failed in staging, but the logs don't provide much info. This should provide more information in the error logs.