### PR TITLE
Removed all non-post handlers from proxy endpoint

### DIFF
--- a/src/plugins/proxy.ts
+++ b/src/plugins/proxy.ts
@@ -9,7 +9,7 @@ async function proxyPlugin(fastify: FastifyInstance) {
         upstream: process.env.PROXY_TARGET || 'http://localhost:3000/local-proxy',
         prefix: '/tb/web_analytics',
         rewritePrefix: '', // Remove the prefix when forwarding
-        httpMethods: ['GET', 'POST', 'PUT', 'DELETE'],
+        httpMethods: ['POST'],
         preValidation: validateRequestWithSchema as FastifyHttpProxyOptions['preValidation'],
         preHandler: processRequest as FastifyHttpProxyOptions['preHandler'],
         replyOptions: {


### PR DESCRIPTION
The proxy endpoint currently accepts GET, PUT and DELETE requests, even though it really only needs to support POST requests. These requests fail validation since they don't include a payload or the right query parameters, thus returning 400, but they really should return 404 to indicate that the route doesn't even exist.