### PR TITLE
Added `site_uuid` to payload in page-hit-processed schema

### DIFF
--- a/src/schemas/v1/page-hit-processed.ts
+++ b/src/schemas/v1/page-hit-processed.ts
@@ -30,6 +30,7 @@ export const PageHitProcessedSchema = Type.Object({
     site_uuid: Type.String({format: 'uuid'}),
     session_id: Type.String(),
     payload: Type.Object({
+        site_uuid: Type.String({format: 'uuid'}),
         member_uuid: Type.Union([Type.String({format: 'uuid'}), Type.Literal('undefined')]),
         member_status: Type.Union([Type.String({minLength: 1}), Type.Literal('undefined')]),
         post_uuid: Type.Union([Type.String({format: 'uuid'}), Type.Literal('undefined')]),
@@ -155,6 +156,7 @@ export async function transformPageHitRawToProcessed(
         site_uuid: pageHitRaw.site_uuid,
         session_id: sessionId,
         payload: {
+            site_uuid: pageHitRaw.site_uuid,
             ...pageHitRaw.payload,
             ...userAgentData,
             ...referrerData

--- a/test/unit/schemas/v1/page-hit-processed.test.ts
+++ b/test/unit/schemas/v1/page-hit-processed.test.ts
@@ -323,6 +323,7 @@ describe('PageHitProcessedSchema v1', () => {
             expect(result.session_id).toHaveLength(64);
         
             // Check original payload fields are preserved
+            expect(result.payload.site_uuid).toBe(validPageHitRaw.site_uuid);
             expect(result.payload.member_uuid).toBe(validPageHitRaw.payload.member_uuid);
             expect(result.payload.member_status).toBe(validPageHitRaw.payload.member_status);
             expect(result.payload.pathname).toBe(validPageHitRaw.payload.pathname);

--- a/test/unit/schemas/v1/page-hit-processed.test.ts
+++ b/test/unit/schemas/v1/page-hit-processed.test.ts
@@ -39,6 +39,7 @@ describe('PageHitProcessedSchema v1', () => {
         site_uuid: '12345678-1234-1234-1234-123456789012',
         session_id: 'abc123def456',
         payload: {
+            site_uuid: '12345678-1234-1234-1234-123456789012',
             member_uuid: 'undefined',
             member_status: 'free',
             post_uuid: 'undefined',


### PR DESCRIPTION
The events sent from the batch worker, which have gone through the schema-based pipeline were ending up in Tinybird's quarantined rows, because they didn't have the `payload.site_uuid` key. This adds the `site_uuid` to the payload, so it will pass Tinybird's ingestion validation.