### PR TITLE
Deduplicated the `FormatRegistry` TypeBox calls from the schema files

### DIFF
--- a/src/schemas/format-registry.ts
+++ b/src/schemas/format-registry.ts
@@ -1,0 +1,26 @@
+import {FormatRegistry} from '@sinclair/typebox';
+import validator from '@tryghost/validator';
+
+/**
+ * Registers all format validators used by schemas.
+ * This should be called once at application startup to ensure
+ * format validators are available before any schema usage.
+ */
+export function registerFormatValidators(): void {
+    // UUID format validator using @tryghost/validator
+    FormatRegistry.Set('uuid', (value) => {
+        return validator.isUUID(value);
+    });
+
+    // URI format validator using @tryghost/validator
+    FormatRegistry.Set('uri', (value) => {
+        return validator.isURL(value);
+    });
+
+    // ISO8601 date-time format validator
+    FormatRegistry.Set('date-time', (value) => {
+        // Use native Date parsing which handles ISO8601 formats properly
+        const date = new Date(value);
+        return !isNaN(date.getTime()) && date.toISOString() === value;
+    });
+}

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,3 +1,8 @@
+import {registerFormatValidators} from './format-registry';
+
+// Ensure format validators are registered before any schema usage
+registerFormatValidators();
+
 // Export current version (v1)
 export * from './v1';
 

--- a/src/schemas/v1/incoming-event-request.ts
+++ b/src/schemas/v1/incoming-event-request.ts
@@ -1,20 +1,4 @@
-import {Type, FormatRegistry} from '@sinclair/typebox';
-import validator from '@tryghost/validator';
-
-// Register format validators for runtime validation using @tryghost/validator
-FormatRegistry.Set('uuid', (value) => {
-    return validator.isUUID(value);
-});
-
-FormatRegistry.Set('uri', (value) => {
-    return validator.isURL(value);
-});
-
-FormatRegistry.Set('date-time', (value) => {
-    // Use native Date parsing which handles ISO8601 formats properly
-    const date = new Date(value);
-    return !isNaN(date.getTime()) && date.toISOString() === value;
-});
+import {Type} from '@sinclair/typebox';
 
 // Common types
 const StringSchema = Type.String();

--- a/src/schemas/v1/index.ts
+++ b/src/schemas/v1/index.ts
@@ -1,2 +1,3 @@
 export * from './incoming-event-request';
 export * from './page-hit-raw';
+export * from './page-hit-processed';

--- a/src/schemas/v1/page-hit-processed.ts
+++ b/src/schemas/v1/page-hit-processed.ts
@@ -1,24 +1,8 @@
-import {Type, Static, FormatRegistry} from '@sinclair/typebox';
-import validator from '@tryghost/validator';
+import {Type, Static} from '@sinclair/typebox';
 import {PageHitRaw} from './page-hit-raw';
 import uap from 'ua-parser-js';
 import {ReferrerParser} from '@tryghost/referrer-parser';
 import {userSignatureService} from '../../services/user-signature';
-
-// Register format validators for runtime validation using @tryghost/validator
-FormatRegistry.Set('uuid', (value) => {
-    return validator.isUUID(value);
-});
-
-FormatRegistry.Set('uri', (value) => {
-    return validator.isURL(value);
-});
-
-FormatRegistry.Set('date-time', (value) => {
-    // Use native Date parsing which handles ISO8601 formats properly
-    const date = new Date(value);
-    return !isNaN(date.getTime()) && date.toISOString() === value;
-});
 
 const referrerParser = new ReferrerParser();
 

--- a/src/schemas/v1/page-hit-raw.ts
+++ b/src/schemas/v1/page-hit-raw.ts
@@ -1,20 +1,4 @@
-import {Type, FormatRegistry, Static} from '@sinclair/typebox';
-import validator from '@tryghost/validator';
-
-// Register format validators for runtime validation using @tryghost/validator
-FormatRegistry.Set('uuid', (value) => {
-    return validator.isUUID(value);
-});
-
-FormatRegistry.Set('uri', (value) => {
-    return validator.isURL(value);
-});
-
-FormatRegistry.Set('date-time', (value) => {
-    // Use native Date parsing which handles ISO8601 formats properly
-    const date = new Date(value);
-    return !isNaN(date.getTime()) && date.toISOString() === value;
-});
+import {Type, Static} from '@sinclair/typebox';
 
 // Common types
 const StringSchema = Type.String();

--- a/src/services/batch-worker/BatchWorker.ts
+++ b/src/services/batch-worker/BatchWorker.ts
@@ -1,7 +1,6 @@
 import {Message} from '@google-cloud/pubsub';
 import {EventSubscriber} from '../events/subscriber';
-import {PageHitRaw, PageHitRawSchema} from '../../schemas/v1/page-hit-raw';
-import {PageHitProcessed, transformPageHitRawToProcessed} from '../../schemas/v1/page-hit-processed';
+import {PageHitRaw, PageHitRawSchema, PageHitProcessed, transformPageHitRawToProcessed} from '../../schemas';
 import {Value} from '@sinclair/typebox/value';
 import {TinybirdClient} from '../tinybird/client';
 import logger from '../../utils/logger';

--- a/src/services/proxy/proxy.ts
+++ b/src/services/proxy/proxy.ts
@@ -5,8 +5,7 @@ import {parseUserAgent} from './processors/parse-user-agent';
 import {generateUserSignature} from './processors/user-signature';
 import {publishEvent} from '../events/publisher.js';
 import {TypeCompiler} from '@sinclair/typebox/compiler';
-import {QueryParamsSchema, HeadersSchema, BodySchema} from '../../schemas/v1/incoming-event-request';
-import {PageHitRaw} from '../../schemas/v1/page-hit-raw';
+import {QueryParamsSchema, HeadersSchema, BodySchema, PageHitRaw} from '../../schemas';
 import {Static} from '@sinclair/typebox';
 
 // Compile schema validators once for performance

--- a/test/unit/schemas/v1/incoming-event-request.test.ts
+++ b/test/unit/schemas/v1/incoming-event-request.test.ts
@@ -6,7 +6,7 @@ import {
     PayloadSchema,
     BodySchema,
     IncomingEventRequestSchema
-} from '../../../../src/schemas/v1/incoming-event-request';
+} from '../../../../src/schemas';
 
 describe('IncomingEventRequestSchema v1', () => {
     describe('QueryParamsSchema', () => {

--- a/test/unit/schemas/v1/page-hit-processed.test.ts
+++ b/test/unit/schemas/v1/page-hit-processed.test.ts
@@ -5,9 +5,9 @@ import {
     transformUserAgent,
     transformReferrer,
     generateUserSignature,
-    transformPageHitRawToProcessed
-} from '../../../../src/schemas/v1/page-hit-processed';
-import {PageHitRaw} from '../../../../src/schemas/v1/page-hit-raw';
+    transformPageHitRawToProcessed,
+    PageHitRaw
+} from '../../../../src/schemas';
 
 const validPageHitRaw: PageHitRaw = {
     timestamp: '2024-01-01T00:00:00.000Z',

--- a/test/unit/schemas/v1/page-hit-raw.test.ts
+++ b/test/unit/schemas/v1/page-hit-raw.test.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect} from 'vitest';
 import {Value} from '@sinclair/typebox/value';
-import {PageHitRawSchema} from '../../../../src/schemas/v1/page-hit-raw';
+import {PageHitRawSchema} from '../../../../src/schemas';
 
 describe('PageHitRawSchema v1', () => {
     const validPageHitRaw = {


### PR DESCRIPTION
The `FormatRegistry` calls allow Typebox to enforce validation rules for specific formats like `uuid` without having to reinvent the wheel for each field. We were registering all the formats within each schema, which needlessly duplicated this code. 

This consolidates all our `FormatRegistry` calls into `schemas/format-registry.ts` and runs it in `schema/index.ts`. This ensures the formats are registered for all our Schemas, so we can just use the formats in the schema files themselves without having to explicitly register them in each schema.