### PR TITLE
Fixed referrer validation failing

### DIFF
--- a/src/schemas/v1/incoming-event-request.ts
+++ b/src/schemas/v1/incoming-event-request.ts
@@ -36,12 +36,20 @@ export const HeadersSchema = Type.Object({
     additionalProperties: Type.Union([StringSchema, Type.Array(StringSchema)])
 });
 
+// Parsed referrer schema
+const ParsedReferrerSchema = Type.Object({
+    source: Type.Union([StringSchema, Type.Null()]),
+    medium: Type.Union([StringSchema, Type.Null()]),
+    url: Type.Union([StringSchema, Type.Null()])
+});
+
 // Payload schema
 export const PayloadSchema = Type.Object({
     'user-agent': NonEmptyStringSchema,
     locale: NonEmptyStringSchema,
     location: Type.Union([NonEmptyStringSchema, Type.Null()]),
-    referrer: Type.Union([StringSchema, Type.Null()]),
+    referrer: Type.Optional(Type.Union([StringSchema, Type.Null()])),
+    parsedReferrer: Type.Optional(ParsedReferrerSchema),
     pathname: NonEmptyStringSchema,
     href: URLSchema,
     site_uuid: UUIDSchema,

--- a/src/schemas/v1/page-hit-processed.ts
+++ b/src/schemas/v1/page-hit-processed.ts
@@ -21,7 +21,7 @@ export const PageHitProcessedSchema = Type.Object({
         post_type: Type.Union([Type.Literal('null'), Type.Literal('post'), Type.Literal('page')]),
         locale: Type.String({minLength: 1}),
         location: Type.Union([Type.String({minLength: 1}), Type.Null()]),
-        referrer: Type.Union([Type.String(), Type.Null()]),
+        referrer: Type.Optional(Type.Union([Type.String(), Type.Null()])),
         pathname: Type.String({minLength: 1}),
         href: Type.String({format: 'uri'}),
         os: Type.String(),
@@ -93,7 +93,7 @@ function isBot(userAgentString: string): boolean {
     return botPattern.test(userAgentString);
 }
 
-export function transformReferrer(referrer: string | null): {
+export function transformReferrer(referrer: string | null | undefined): {
     referrer_url?: string,
     referrer_source?: string,
     referrer_medium?: string
@@ -133,6 +133,8 @@ export async function transformPageHitRawToProcessed(
         pageHitRaw.meta['user-agent']
     );
 
+    const referrer = pageHitRaw.payload.parsedReferrer?.source ?? pageHitRaw.payload.referrer ?? null;
+
     return {
         timestamp: pageHitRaw.timestamp,
         action: pageHitRaw.action,
@@ -142,6 +144,7 @@ export async function transformPageHitRawToProcessed(
         payload: {
             site_uuid: pageHitRaw.site_uuid,
             ...pageHitRaw.payload,
+            referrer,
             ...userAgentData,
             ...referrerData
         }

--- a/src/schemas/v1/page-hit-raw.ts
+++ b/src/schemas/v1/page-hit-raw.ts
@@ -15,9 +15,9 @@ const VersionSchema = Type.Literal('1');
 
 // Parsed referrer schema
 const ParsedReferrerSchema = Type.Object({
-    source: Type.Optional(StringSchema),
-    medium: Type.Optional(StringSchema),
-    url: Type.Optional(StringSchema)
+    source: Type.Union([StringSchema, Type.Null()]),
+    medium: Type.Union([StringSchema, Type.Null()]),
+    url: Type.Union([StringSchema, Type.Null()])
 });
 
 // Payload schema for page hit raw events

--- a/src/schemas/v1/page-hit-raw.ts
+++ b/src/schemas/v1/page-hit-raw.ts
@@ -13,6 +13,13 @@ const ISO8601DateTimeSchema = Type.String({
 const ActionSchema = Type.Literal('page_hit');
 const VersionSchema = Type.Literal('1');
 
+// Parsed referrer schema
+const ParsedReferrerSchema = Type.Object({
+    source: Type.Optional(StringSchema),
+    medium: Type.Optional(StringSchema),
+    url: Type.Optional(StringSchema)
+});
+
 // Payload schema for page hit raw events
 const PayloadSchema = Type.Object({
     member_uuid: Type.Union([UUIDSchema, Type.Literal('undefined')]),
@@ -21,7 +28,8 @@ const PayloadSchema = Type.Object({
     post_type: Type.Union([Type.Literal('null'), Type.Literal('post'), Type.Literal('page')]),
     locale: NonEmptyStringSchema,
     location: Type.Union([NonEmptyStringSchema, Type.Null()]),
-    referrer: Type.Union([StringSchema, Type.Null()]),
+    referrer: Type.Optional(Type.Union([StringSchema, Type.Null()])),
+    parsedReferrer: Type.Optional(ParsedReferrerSchema),
     pathname: NonEmptyStringSchema,
     href: URLSchema
 });

--- a/src/services/proxy/proxy.ts
+++ b/src/services/proxy/proxy.ts
@@ -32,7 +32,8 @@ const pageHitRawPayloadFromRequest = (request: ValidatedRequest): PageHitRaw => 
             post_type: request.body.payload.post_type,
             locale: request.body.payload.locale,
             location: request.body.payload.location,
-            referrer: request.body.payload.referrer,
+            referrer: request.body.payload.referrer ?? null,
+            parsedReferrer: request.body.payload.parsedReferrer,
             pathname: request.body.payload.pathname,
             href: request.body.payload.href
         },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@ export interface Payload {
     'user-agent': string;
     locale: string;
     location: string | null;
-    referrer: string | null;
+    referrer?: string | null;
     parsedReferrer?: {
         source: string | null;
         medium: string | null;

--- a/test/unit/schemas/v1/incoming-event-request.test.ts
+++ b/test/unit/schemas/v1/incoming-event-request.test.ts
@@ -144,6 +144,22 @@ describe('IncomingEventRequestSchema v1', () => {
             expect(Value.Check(PayloadSchema, payloadWithNullReferrer)).toBe(true);
         });
 
+        it('should validate without referrer field (optional)', () => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const {referrer, ...payloadWithoutReferrer} = validPayload;
+        
+            expect(Value.Check(PayloadSchema, payloadWithoutReferrer)).toBe(true);
+        });
+
+        it('should validate with empty string referrer', () => {
+            const payloadWithEmptyReferrer = {
+                ...validPayload,
+                referrer: ''
+            };
+        
+            expect(Value.Check(PayloadSchema, payloadWithEmptyReferrer)).toBe(true);
+        });
+
         it('should validate with UUID post_uuid', () => {
             const payloadWithUUIDPost = {
                 ...validPayload,
@@ -232,6 +248,67 @@ describe('IncomingEventRequestSchema v1', () => {
             
             expect(Value.Check(PayloadSchema, healthcheckPayload)).toBe(true);
         });
+
+        it('should validate with parsedReferrer object with all string values', () => {
+            const payloadWithParsedReferrer = {
+                ...validPayload,
+                parsedReferrer: {
+                    source: 'google',
+                    medium: 'organic',
+                    url: 'https://google.com'
+                }
+            };
+        
+            expect(Value.Check(PayloadSchema, payloadWithParsedReferrer)).toBe(true);
+        });
+
+        it('should validate with parsedReferrer object with mixed null and string values', () => {
+            const payloadWithMixedParsedReferrer = {
+                ...validPayload,
+                parsedReferrer: {
+                    source: 'facebook',
+                    medium: null,
+                    url: 'https://facebook.com'
+                }
+            };
+        
+            expect(Value.Check(PayloadSchema, payloadWithMixedParsedReferrer)).toBe(true);
+        });
+
+        it('should validate without parsedReferrer field (optional)', () => {
+            const payloadWithoutParsedReferrer = {
+                ...validPayload
+                // parsedReferrer field omitted
+            };
+        
+            expect(Value.Check(PayloadSchema, payloadWithoutParsedReferrer)).toBe(true);
+        });
+
+        it('should reject parsedReferrer with missing required fields', () => {
+            const payloadWithIncompleteParsedReferrer = {
+                ...validPayload,
+                parsedReferrer: {
+                    source: 'google',
+                    medium: 'organic'
+                    // missing url field
+                }
+            };
+        
+            expect(Value.Check(PayloadSchema, payloadWithIncompleteParsedReferrer)).toBe(false);
+        });
+
+        it('should reject parsedReferrer with invalid field types', () => {
+            const payloadWithInvalidParsedReferrer = {
+                ...validPayload,
+                parsedReferrer: {
+                    source: 123, // should be string or null
+                    medium: 'organic',
+                    url: 'https://google.com'
+                }
+            };
+        
+            expect(Value.Check(PayloadSchema, payloadWithInvalidParsedReferrer)).toBe(false);
+        });
     });
 
     describe('BodySchema', () => {
@@ -244,7 +321,6 @@ describe('IncomingEventRequestSchema v1', () => {
                 'user-agent': 'Mozilla/5.0',
                 locale: 'en-US',
                 location: 'homepage',
-                referrer: null,
                 pathname: '/blog',
                 href: 'https://example.com/blog',
                 site_uuid: '12345678-1234-1234-1234-123456789012',
@@ -309,7 +385,6 @@ describe('IncomingEventRequestSchema v1', () => {
                     'user-agent': 'Mozilla/5.0',
                     locale: 'en-US',
                     location: 'homepage',
-                    referrer: null,
                     pathname: '/blog',
                     href: 'https://example.com/blog',
                     site_uuid: '12345678-1234-1234-1234-123456789012',

--- a/test/unit/schemas/v1/page-hit-raw.test.ts
+++ b/test/unit/schemas/v1/page-hit-raw.test.ts
@@ -213,6 +213,102 @@ describe('PageHitRawSchema v1', () => {
             expect(Value.Check(PageHitRawSchema, validData)).toBe(true);
         });
 
+        it('should validate without referrer field (optional)', () => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const {referrer, ...payloadWithoutReferrer} = validPageHitRaw.payload;
+            const validData = {
+                ...validPageHitRaw,
+                payload: payloadWithoutReferrer
+            };
+            expect(Value.Check(PageHitRawSchema, validData)).toBe(true);
+        });
+
+        it('should validate with parsedReferrer object with all string values', () => {
+            const validData = {
+                ...validPageHitRaw,
+                payload: {
+                    ...validPageHitRaw.payload,
+                    parsedReferrer: {
+                        source: 'google',
+                        medium: 'organic',
+                        url: 'https://google.com'
+                    }
+                }
+            };
+            expect(Value.Check(PageHitRawSchema, validData)).toBe(true);
+        });
+
+        it('should validate with parsedReferrer object with null values', () => {
+            const validData = {
+                ...validPageHitRaw,
+                payload: {
+                    ...validPageHitRaw.payload,
+                    parsedReferrer: {
+                        source: null,
+                        medium: null,
+                        url: null
+                    }
+                }
+            };
+            expect(Value.Check(PageHitRawSchema, validData)).toBe(true);
+        });
+
+        it('should validate with parsedReferrer object with mixed null and string values', () => {
+            const validData = {
+                ...validPageHitRaw,
+                payload: {
+                    ...validPageHitRaw.payload,
+                    parsedReferrer: {
+                        source: 'facebook',
+                        medium: null,
+                        url: 'https://facebook.com'
+                    }
+                }
+            };
+            expect(Value.Check(PageHitRawSchema, validData)).toBe(true);
+        });
+
+        it('should validate without parsedReferrer field (optional)', () => {
+            const validData = {
+                ...validPageHitRaw,
+                payload: {
+                    ...validPageHitRaw.payload
+                    // parsedReferrer field omitted
+                }
+            };
+            expect(Value.Check(PageHitRawSchema, validData)).toBe(true);
+        });
+
+        it('should reject parsedReferrer with missing required fields', () => {
+            const invalidData = {
+                ...validPageHitRaw,
+                payload: {
+                    ...validPageHitRaw.payload,
+                    parsedReferrer: {
+                        source: 'google',
+                        medium: 'organic'
+                        // missing url field
+                    }
+                }
+            };
+            expect(Value.Check(PageHitRawSchema, invalidData)).toBe(false);
+        });
+
+        it('should reject parsedReferrer with invalid field types', () => {
+            const invalidData = {
+                ...validPageHitRaw,
+                payload: {
+                    ...validPageHitRaw.payload,
+                    parsedReferrer: {
+                        source: 123, // should be string or null
+                        medium: 'organic',
+                        url: 'https://google.com'
+                    }
+                }
+            };
+            expect(Value.Check(PageHitRawSchema, invalidData)).toBe(false);
+        });
+
         it('should reject invalid href URL', () => {
             const invalidData = {
                 ...validPageHitRaw,
@@ -369,6 +465,37 @@ describe('PageHitRawSchema v1', () => {
             };
             
             expect(Value.Check(PageHitRawSchema, realWorldPayload)).toBe(true);
+        });
+
+        it('should validate payload with parsedReferrer', () => {
+            const realWorldPayloadWithParsedReferrer = {
+                timestamp: '2024-06-24T10:30:00.000Z',
+                action: 'page_hit',
+                version: '1',
+                site_uuid: 'c7929de8-27d7-404e-b714-0fc774f701e6',
+                payload: {
+                    member_uuid: 'undefined',
+                    member_status: 'undefined',
+                    post_uuid: 'undefined',
+                    post_type: 'null',
+                    locale: 'en-US',
+                    location: null,
+                    referrer: 'https://google.com/search?q=example',
+                    parsedReferrer: {
+                        source: 'google',
+                        medium: 'organic',
+                        url: 'https://google.com'
+                    },
+                    pathname: '/blog/post',
+                    href: 'https://example.com/blog/post'
+                },
+                meta: {
+                    ip: '203.0.113.42',
+                    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.7204.23 Safari/537.36'
+                }
+            };
+            
+            expect(Value.Check(PageHitRawSchema, realWorldPayloadWithParsedReferrer)).toBe(true);
         });
     });
 });


### PR DESCRIPTION
The `ghost-stats` script no longer sends the `referrer` field directly, instead sending a `parsedReferrer` object. This service treats the referrer as a required value, and therefore any requests from the `ghost-stats` script are failing the validation, and thus not ending up in Tinybird.

This commit makes the referrer field optional, and adds an optional `parsedReferrer` field, so that these requests should pass validation and succeed.