### PR TITLE
v0.0.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traffic-analytics",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "repository": "git@github.com:TryGhost/TrafficAnalytics.git",
   "author": "Ghost Foundation",
   "license": "MIT",


### PR DESCRIPTION
Fixed validation errors when `referrer` is not included in request.