### PR TITLE
Updated compose services to use Firestore for salt storage

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -54,6 +54,8 @@ services:
       - NODE_ENV=${NODE_ENV:-development}
       - GOOGLE_CLOUD_PROJECT=traffic-analytics-dev
       - FIRESTORE_EMULATOR_HOST=firestore:8080
+      - FIRESTORE_DATABASE_ID=traffic-analytics-dev
+      - SALT_STORE_TYPE=firestore
       - PUBSUB_EMULATOR_HOST=pubsub:8085
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
       - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
@@ -88,6 +90,8 @@ services:
       - WORKER_MODE=true
       - GOOGLE_CLOUD_PROJECT=traffic-analytics-dev
       - FIRESTORE_EMULATOR_HOST=firestore:8080
+      - FIRESTORE_DATABASE_ID=traffic-analytics-dev
+      - SALT_STORE_TYPE=firestore
       - PUBSUB_EMULATOR_HOST=pubsub:8085
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
       - PUBSUB_SUBSCRIPTION_PAGE_HITS_RAW=traffic-analytics-page-hits-raw-sub


### PR DESCRIPTION
The service and the worker were both defaulting to the memory store when running locally, resulting in mismatching user signatures. This isn't really a problem since we use Firestore in production, but it did give me a scare. This points both services to use the Firestore emulator in docker compose for salt storage, so the user signatures match from each service for the same request.