### PR TITLE
Updated referrer fields in schema to match the proxy

### DIFF
--- a/src/schemas/v1/page-hit-processed.ts
+++ b/src/schemas/v1/page-hit-processed.ts
@@ -27,10 +27,11 @@ export const PageHitProcessedSchema = Type.Object({
         os: Type.String(),
         browser: Type.String(),
         device: Type.String(),
-        referrer_url: Type.Optional(Type.String()),
-        referrer_source: Type.Optional(Type.String()),
-        referrer_medium: Type.Optional(Type.String()),
+        referrerUrl: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        referrerSource: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        referrerMedium: Type.Optional(Type.Union([Type.String(), Type.Null()])),
         'user-agent': Type.String()
+
     })
 });
 
@@ -95,9 +96,9 @@ function isBot(userAgentString: string): boolean {
 }
 
 export function transformReferrer(referrer: string | null | undefined): {
-    referrer_url?: string,
-    referrer_source?: string,
-    referrer_medium?: string
+    referrerUrl?: string | null,
+    referrerSource?: string | null,
+    referrerMedium?: string | null
 } {
     if (!referrer || !referrerParser) {
         return {};
@@ -106,9 +107,9 @@ export function transformReferrer(referrer: string | null | undefined): {
     try {
         const parsedReferrer = referrerParser.parse(referrer);
         return {
-            referrer_url: parsedReferrer.referrerUrl || undefined,
-            referrer_source: parsedReferrer.referrerSource || undefined,
-            referrer_medium: parsedReferrer.referrerMedium || undefined
+            referrerUrl: parsedReferrer.referrerUrl || null,
+            referrerSource: parsedReferrer.referrerSource || null,
+            referrerMedium: parsedReferrer.referrerMedium || null
         };
     } catch (error) {
         return {};

--- a/test/unit/schemas/v1/page-hit-processed.test.ts
+++ b/test/unit/schemas/v1/page-hit-processed.test.ts
@@ -254,18 +254,18 @@ describe('PageHitProcessedSchema v1', () => {
             const referrer = 'https://www.google.com/search?q=test';
             const result = transformReferrer(referrer);
         
-            expect(result.referrer_url).toBe('www.google.com');
-            expect(result.referrer_source).toBe('Google');
-            expect(result.referrer_medium).toBe('search');
+            expect(result.referrerUrl).toBe('www.google.com');
+            expect(result.referrerSource).toBe('Google');
+            expect(result.referrerMedium).toBe('search');
         });
 
         it('should parse social media referrer correctly', () => {
             const referrer = 'https://twitter.com/user/status/123';
             const result = transformReferrer(referrer);
         
-            expect(result.referrer_url).toBe('twitter.com');
-            expect(result.referrer_source).toBe('Twitter');
-            expect(result.referrer_medium).toBe('social');
+            expect(result.referrerUrl).toBe('twitter.com');
+            expect(result.referrerSource).toBe('Twitter');
+            expect(result.referrerMedium).toBe('social');
         });
 
         it('should handle null referrer', () => {
@@ -284,15 +284,19 @@ describe('PageHitProcessedSchema v1', () => {
             const referrer = 'https://example.com/some-page';
             const result = transformReferrer(referrer);
         
-            expect(result.referrer_url).toBe('example.com');
-            expect(result.referrer_source).toBe('example.com');
-            expect(result.referrer_medium).toBeUndefined();
+            expect(result.referrerUrl).toBe('example.com');
+            expect(result.referrerSource).toBe('example.com');
+            expect(result.referrerMedium).toBe(null);
         });
 
         it('should handle malformed referrer gracefully', () => {
             const result = transformReferrer('not-a-url');
         
-            expect(result).toEqual({});
+            expect(result).toEqual({
+                referrerUrl: null,
+                referrerSource: null,
+                referrerMedium: null
+            });
         });
     });
 
@@ -345,9 +349,10 @@ describe('PageHitProcessedSchema v1', () => {
             expect(result.payload.os).toBe('macos');
             expect(result.payload.browser).toBe('chrome');
             expect(result.payload.device).toBe('desktop');
-            expect(result.payload.referrer_url).toBe('google.com');
-            expect(result.payload.referrer_source).toBe('Google');
-            expect(result.payload.referrer_medium).toBe('search');
+
+            expect(result.payload.referrerUrl).toBe('google.com');
+            expect(result.payload.referrerSource).toBe('Google');
+            expect(result.payload.referrerMedium).toBe('search');
             expect(result.payload['user-agent']).toBe(validPageHitRaw.meta['user-agent']);
         
             // Check meta is not included in processed output
@@ -365,9 +370,9 @@ describe('PageHitProcessedSchema v1', () => {
         
             const result = await transformPageHitRawToProcessed(pageHitRawWithNullReferrer);
         
-            expect(result.payload.referrer_url).toBeUndefined();
-            expect(result.payload.referrer_source).toBeUndefined();
-            expect(result.payload.referrer_medium).toBeUndefined();
+            expect(result.payload.referrerUrl).toBeUndefined();
+            expect(result.payload.referrerSource).toBeUndefined();
+            expect(result.payload.referrerMedium).toBeUndefined();
         });
 
         it('should handle page hit raw with bot user agent', async () => {


### PR DESCRIPTION
The referrer fields in the page-hit-processed schema didn't quite match up with the current behavior from the proxy endpoint. This updates the schema to match, such that the events landing in `analytics_events` from the proxy should be identical to those landing in `analytics_events_test`.