### PR TITLE
Fixed batch worker throwing error when POST request fails

### DIFF
--- a/src/services/batch-worker/BatchWorker.ts
+++ b/src/services/batch-worker/BatchWorker.ts
@@ -38,7 +38,6 @@ class BatchWorker {
         } catch (error) {
             logger.error({messageData: message.data.toString(), error}, 'Worker unable to process message. Nacking message...');
             message.nack();
-            throw error;
         }
     }
 

--- a/test/unit/services/batch-worker/batch-worker.test.ts
+++ b/test/unit/services/batch-worker/batch-worker.test.ts
@@ -199,7 +199,7 @@ describe('BatchWorker', () => {
             
             (mockTinybirdClient.postEvent as any).mockRejectedValueOnce(tinybirdError);
 
-            await expect((batchWorker as any).handleMessage(mockMessage)).rejects.toThrow('Tinybird API error');
+            await (batchWorker as any).handleMessage(mockMessage);
 
             expectMessageNacked(mockMessage);
         });
@@ -208,7 +208,7 @@ describe('BatchWorker', () => {
             const invalidJson = 'invalid json';
             const mockMessage = createMockMessage(invalidJson);
 
-            await expect((batchWorker as any).handleMessage(mockMessage)).rejects.toThrow();
+            await (batchWorker as any).handleMessage(mockMessage);
 
             expectMessageNacked(mockMessage);
         });
@@ -221,7 +221,7 @@ describe('BatchWorker', () => {
             };
             const mockMessage = createMockMessage(JSON.stringify(invalidData));
 
-            await expect((batchWorker as any).handleMessage(mockMessage)).rejects.toThrow();
+            await (batchWorker as any).handleMessage(mockMessage);
 
             expectMessageNacked(mockMessage);
         });
@@ -234,7 +234,7 @@ describe('BatchWorker', () => {
             };
             const mockMessage = createMockMessage(JSON.stringify(incompleteData));
 
-            await expect((batchWorker as any).handleMessage(mockMessage)).rejects.toThrow();
+            await (batchWorker as any).handleMessage(mockMessage);
 
             expectMessageNacked(mockMessage);
         });
@@ -242,7 +242,7 @@ describe('BatchWorker', () => {
         it('should handle empty message data', async () => {
             const mockMessage = createMockMessage('');
 
-            await expect((batchWorker as any).handleMessage(mockMessage)).rejects.toThrow();
+            await (batchWorker as any).handleMessage(mockMessage);
 
             expectMessageNacked(mockMessage);
         });
@@ -289,7 +289,7 @@ describe('BatchWorker', () => {
             };
             const mockMessage = createMockMessage(JSON.stringify(invalidUuidData));
 
-            await expect((batchWorker as any).handleMessage(mockMessage)).rejects.toThrow();
+            await (batchWorker as any).handleMessage(mockMessage);
 
             expectMessageNacked(mockMessage);
         });
@@ -304,7 +304,7 @@ describe('BatchWorker', () => {
             };
             const mockMessage = createMockMessage(JSON.stringify(invalidUrlData));
 
-            await expect((batchWorker as any).handleMessage(mockMessage)).rejects.toThrow();
+            await (batchWorker as any).handleMessage(mockMessage);
 
             expectMessageNacked(mockMessage);
         });


### PR DESCRIPTION
When a POST request to Tinybird from the batch worker fails (for whatever reason, ie `EHOSTUNREACH` errors), the batch worker is catching the error, logging it then rethrowing it and crashing.  These transient errors will always happen, so we definitely don't want to rethrow this error and crash. 

This removes the rethrow — we're nacking the message so it will be retried, and this allows the worker to keep processing messages without interruption. 