### PR TITLE
Added optional `event_id` field to payload in schemas

### DIFF
--- a/src/schemas/v1/incoming-event-request.ts
+++ b/src/schemas/v1/incoming-event-request.ts
@@ -45,6 +45,7 @@ const ParsedReferrerSchema = Type.Object({
 
 // Payload schema
 export const PayloadSchema = Type.Object({
+    event_id: Type.Optional(StringSchema),
     'user-agent': NonEmptyStringSchema,
     locale: NonEmptyStringSchema,
     location: Type.Union([NonEmptyStringSchema, Type.Null()]),

--- a/src/schemas/v1/page-hit-processed.ts
+++ b/src/schemas/v1/page-hit-processed.ts
@@ -14,6 +14,7 @@ export const PageHitProcessedSchema = Type.Object({
     site_uuid: Type.String({format: 'uuid'}),
     session_id: Type.String(),
     payload: Type.Object({
+        event_id: Type.String({format: 'uuid'}),
         site_uuid: Type.String({format: 'uuid'}),
         member_uuid: Type.Union([Type.String({format: 'uuid'}), Type.Literal('undefined')]),
         member_status: Type.Union([Type.String({minLength: 1}), Type.Literal('undefined')]),
@@ -144,6 +145,7 @@ export async function transformPageHitRawToProcessed(
         site_uuid: pageHitRaw.site_uuid,
         session_id: sessionId,
         payload: {
+            event_id: pageHitRaw.payload.event_id ?? crypto.randomUUID(),
             site_uuid: pageHitRaw.site_uuid,
             ...pageHitRaw.payload,
             referrer,

--- a/src/schemas/v1/page-hit-raw.ts
+++ b/src/schemas/v1/page-hit-raw.ts
@@ -22,6 +22,7 @@ const ParsedReferrerSchema = Type.Object({
 
 // Payload schema for page hit raw events
 const PayloadSchema = Type.Object({
+    event_id: Type.Optional(StringSchema),
     member_uuid: Type.Union([UUIDSchema, Type.Literal('undefined')]),
     member_status: Type.Union([NonEmptyStringSchema, Type.Literal('undefined')]),
     post_uuid: Type.Union([UUIDSchema, Type.Literal('undefined')]),

--- a/test/unit/schemas/v1/page-hit-processed.test.ts
+++ b/test/unit/schemas/v1/page-hit-processed.test.ts
@@ -15,6 +15,7 @@ const validPageHitRaw: PageHitRaw = {
     version: '1',
     site_uuid: '12345678-1234-1234-1234-123456789012',
     payload: {
+        event_id: '550e8400-e29b-41d4-a716-446655440000',
         member_uuid: 'undefined',
         member_status: 'free',
         post_uuid: 'undefined',
@@ -39,6 +40,7 @@ describe('PageHitProcessedSchema v1', () => {
         site_uuid: '12345678-1234-1234-1234-123456789012',
         session_id: 'abc123def456',
         payload: {
+            event_id: '550e8400-e29b-41d4-a716-446655440000',
             site_uuid: '12345678-1234-1234-1234-123456789012',
             member_uuid: 'undefined',
             member_status: 'free',

--- a/test/unit/schemas/v1/page-hit-raw.test.ts
+++ b/test/unit/schemas/v1/page-hit-raw.test.ts
@@ -9,6 +9,7 @@ describe('PageHitRawSchema v1', () => {
         version: '1',
         site_uuid: '12345678-1234-1234-1234-123456789012',
         payload: {
+            event_id: '550e8400-e29b-41d4-a716-446655440000',
             member_uuid: 'undefined',
             member_status: 'free',
             post_uuid: 'undefined',
@@ -440,6 +441,33 @@ describe('PageHitRawSchema v1', () => {
         });
     });
 
+    describe('event_id validation', () => {
+        it('should validate when event_id is present', () => {
+            expect(Value.Check(PageHitRawSchema, validPageHitRaw)).toBe(true);
+        });
+
+        it('should validate when event_id is missing (optional field)', () => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const {event_id: eventId, ...payloadWithoutEventId} = validPageHitRaw.payload;
+            const validDataWithoutEventId = {
+                ...validPageHitRaw,
+                payload: payloadWithoutEventId
+            };
+            expect(Value.Check(PageHitRawSchema, validDataWithoutEventId)).toBe(true);
+        });
+
+        it('should accept any string as event_id (validation happens during processing)', () => {
+            const dataWithInvalidEventId = {
+                ...validPageHitRaw,
+                payload: {
+                    ...validPageHitRaw.payload,
+                    event_id: 'not-a-uuid'
+                }
+            };
+            expect(Value.Check(PageHitRawSchema, dataWithInvalidEventId)).toBe(true);
+        });
+    });
+
     describe('real-world payload validation', () => {
         it('should validate typical payload with null values', () => {
             const realWorldPayload = {
@@ -448,6 +476,7 @@ describe('PageHitRawSchema v1', () => {
                 version: '1',
                 site_uuid: 'c7929de8-27d7-404e-b714-0fc774f701e6',
                 payload: {
+                    event_id: 'c7929de8-27d7-404e-b714-0fc774f701e6',
                     member_uuid: 'undefined',
                     member_status: 'undefined',
                     post_uuid: 'undefined',
@@ -474,6 +503,7 @@ describe('PageHitRawSchema v1', () => {
                 version: '1',
                 site_uuid: 'c7929de8-27d7-404e-b714-0fc774f701e6',
                 payload: {
+                    event_id: 'a1b2c3d4-e5f6-7890-1234-567890abcdef',
                     member_uuid: 'undefined',
                     member_status: 'undefined',
                     post_uuid: 'undefined',

--- a/test/unit/services/batch-worker/batch-worker.test.ts
+++ b/test/unit/services/batch-worker/batch-worker.test.ts
@@ -96,6 +96,7 @@ describe('BatchWorker', () => {
             version: '1',
             site_uuid: '550e8400-e29b-41d4-a716-446655440000',
             payload: {
+                event_id: '123e4567-e89b-12d3-a456-426614174000',
                 member_uuid: 'undefined',
                 member_status: 'undefined',
                 post_uuid: 'undefined',
@@ -304,6 +305,7 @@ describe('BatchWorker', () => {
             version: '1',
             site_uuid: '550e8400-e29b-41d4-a716-446655440000',
             payload: {
+                event_id: '123e4567-e89b-12d3-a456-426614174000',
                 member_uuid: 'undefined',
                 member_status: 'undefined',
                 post_uuid: 'undefined',

--- a/test/unit/services/proxy/proxy.test.ts
+++ b/test/unit/services/proxy/proxy.test.ts
@@ -1,0 +1,50 @@
+import {describe, it, expect} from 'vitest';
+import {ensureValidEventId} from '../../../../src/services/proxy/proxy';
+
+describe('Proxy Service', () => {
+    describe('ensureValidEventId', () => {
+        it('should return valid UUID unchanged', () => {
+            const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+            const result = ensureValidEventId(validUuid);
+            expect(result).toBe(validUuid);
+        });
+
+        it('should generate new UUID for invalid string', () => {
+            const invalidEventId = 'not-a-uuid';
+            const result = ensureValidEventId(invalidEventId);
+            expect(result).not.toBe(invalidEventId);
+            expect(result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+        });
+
+        it('should generate new UUID for undefined', () => {
+            const result = ensureValidEventId(undefined);
+            expect(result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+        });
+
+        it('should generate new UUID for empty string', () => {
+            const result = ensureValidEventId('');
+            expect(result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+        });
+
+        it('should generate new UUID for null', () => {
+            const result = ensureValidEventId(null as any);
+            expect(result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+        });
+
+        it('should handle various invalid UUID formats', () => {
+            const invalidFormats = [
+                'invalid-uuid',
+                '123',
+                'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+                '550e8400-e29b-41d4-a716', // too short
+                '550e8400-e29b-41d4-a716-446655440000-extra' // too long
+            ];
+
+            invalidFormats.forEach((invalidFormat) => {
+                const result = ensureValidEventId(invalidFormat);
+                expect(result).not.toBe(invalidFormat);
+                expect(result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Having a unique identifier for each event will come in handy for debugging, and is currently useful for correlating events sent to `analytics_events` and `analytics_events_test` for validating the batch worker processing.