### PR TITLE
Removed `fastify-http-proxy` in favor of `fastify-reply-from`

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -59,6 +59,7 @@ services:
       - PUBSUB_EMULATOR_HOST=pubsub:8085
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
       - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
+      - TINYBIRD_TRACKER_TOKEN=${TINYBIRD_TRACKER_TOKEN:-}
       - PROXY_TARGET=${PROXY_TARGET:-http://fake-tinybird:8080/v0/events}
     networks:
       - dev-network
@@ -96,6 +97,7 @@ services:
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
       - PUBSUB_SUBSCRIPTION_PAGE_HITS_RAW=traffic-analytics-page-hits-raw-sub
       - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
+      - TINYBIRD_TRACKER_TOKEN=${TINYBIRD_TRACKER_TOKEN:-}
       - PROXY_TARGET=${PROXY_TARGET:-http://fake-tinybird:8080/v0/events}
     networks:
       - dev-network

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@fastify/cors": "11.0.1",
-    "@fastify/http-proxy": "11.3.0",
+    "@fastify/reply-from": "^11.0.0",
     "@fastify/type-provider-typebox": "5.1.0",
     "@google-cloud/firestore": "7.11.2",
     "@google-cloud/pino-logging-gcp-config": "1.0.6",

--- a/src/plugins/proxy.ts
+++ b/src/plugins/proxy.ts
@@ -1,43 +1,71 @@
-import {FastifyInstance} from 'fastify';
+import {FastifyInstance, FastifyRequest, FastifyReply} from 'fastify';
 import fp from 'fastify-plugin';
-import fastifyHttpProxy, {FastifyHttpProxyOptions} from '@fastify/http-proxy';
-import {processRequest, validateRequestWithSchema} from '../services/proxy';
+import replyFrom from '@fastify/reply-from';
+import {processRequest} from '../services/proxy';
+import {QueryParamsSchema, HeadersSchema, BodySchema, IncomingEventRequest} from '../schemas';
 
 async function proxyPlugin(fastify: FastifyInstance) {
-    // Register the analytics proxy using fastify-http-proxy with custom hooks
-    await fastify.register(fastifyHttpProxy, {
-        upstream: process.env.PROXY_TARGET || 'http://localhost:3000/local-proxy',
-        prefix: '/tb/web_analytics',
-        rewritePrefix: '', // Remove the prefix when forwarding
-        httpMethods: ['POST'],
-        preValidation: validateRequestWithSchema as FastifyHttpProxyOptions['preValidation'],
-        preHandler: processRequest as FastifyHttpProxyOptions['preHandler'],
-        replyOptions: {
-            onError: (reply, error) => {
-                // Log proxy errors with proper structure for GCP
-                const unwrappedError = 'error' in error ? error.error : error;
-                reply.log.error({
-                    err: {
-                        message: unwrappedError.message,
-                        stack: unwrappedError.stack,
-                        name: unwrappedError.name
-                    },
-                    httpRequest: {
-                        requestMethod: reply.request.method,
-                        requestUrl: reply.request.url,
-                        userAgent: reply.request.headers['user-agent'],
-                        remoteIp: reply.request.ip,
-                        referer: reply.request.headers.referer,
-                        protocol: `${reply.request.protocol.toUpperCase()}/${reply.request.raw.httpVersion}`,
-                        status: 502
-                    },
-                    upstream: process.env.PROXY_TARGET || 'http://localhost:3000/local-proxy',
-                    type: 'proxy_error'
-                }, 'Proxy error occurred');
-                reply.status(502).send({error: 'Proxy error'});
-            }
-        },
-        disableRequestLogging: process.env.LOG_PROXY_REQUESTS === 'false'
+    // Register reply-from for proxying capabilities
+    await fastify.register(replyFrom);
+
+    // Register the analytics proxy with native schema validation
+    fastify.post('/tb/web_analytics', {
+        schema: {
+            querystring: QueryParamsSchema,
+            headers: HeadersSchema,
+            body: BodySchema
+        }
+    }, async (request: FastifyRequest, reply: FastifyReply) => {
+        try {
+            await processRequest(request as IncomingEventRequest, reply);
+
+            // Proxy the request to the upstream target
+            const upstream = process.env.PROXY_TARGET || 'http://localhost:3000/local-proxy';
+            await reply.from(upstream, {
+                onError: (replyInstance, error) => {
+                    // Log proxy errors with proper structure for GCP
+                    const unwrappedError = 'error' in error ? error.error : error;
+                    replyInstance.log.error({
+                        err: {
+                            message: unwrappedError.message,
+                            stack: unwrappedError.stack,
+                            name: unwrappedError.name
+                        },
+                        httpRequest: {
+                            requestMethod: replyInstance.request.method,
+                            requestUrl: replyInstance.request.url,
+                            userAgent: replyInstance.request.headers['user-agent'],
+                            remoteIp: replyInstance.request.ip,
+                            referer: replyInstance.request.headers.referer,
+                            protocol: `${replyInstance.request.protocol.toUpperCase()}/${replyInstance.request.raw.httpVersion}`,
+                            status: 502
+                        },
+                        upstream: upstream,
+                        type: 'proxy_error'
+                    }, 'Proxy error occurred');
+                    replyInstance.status(502).send({error: 'Proxy error'});
+                }
+            });
+        } catch (error) {
+            reply.log.error({
+                err: error instanceof Error ? {
+                    message: error.message,
+                    stack: error.stack,
+                    name: error.name
+                } : error,
+                httpRequest: {
+                    requestMethod: request.method,
+                    requestUrl: request.url,
+                    userAgent: request.headers['user-agent'],
+                    remoteIp: request.ip,
+                    referer: request.headers.referer,
+                    protocol: `${request.protocol.toUpperCase()}/${request.raw.httpVersion}`,
+                    status: 500
+                },
+                type: 'processing_error'
+            }, 'Request processing error occurred');
+            reply.status(500).send({error: 'Internal server error'});
+        }
     });
     
     // Register local proxy endpoint for development/testing

--- a/src/schemas/v1/incoming-event-request.ts
+++ b/src/schemas/v1/incoming-event-request.ts
@@ -1,4 +1,5 @@
-import {Type} from '@sinclair/typebox';
+import {Static, Type} from '@sinclair/typebox';
+import {FastifyRequest} from 'fastify';
 
 // Common types
 const StringSchema = Type.String();
@@ -77,3 +78,9 @@ export const IncomingEventRequestSchema = Type.Object({
     headers: HeadersSchema,
     body: BodySchema
 });
+
+export interface IncomingEventRequest extends FastifyRequest {
+    query: Static<typeof QueryParamsSchema>;
+    headers: Static<typeof HeadersSchema>;
+    body: Static<typeof BodySchema>;
+}

--- a/src/services/proxy/index.ts
+++ b/src/services/proxy/index.ts
@@ -1,1 +1,1 @@
-export * from './proxy';
+export {processRequest} from './proxy';

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,16 +245,6 @@
   resolved "https://registry.yarnpkg.com/@fastify/forwarded/-/forwarded-3.0.0.tgz#0fc96cdbbb5a38ad453d2d5533a34f09b4949b37"
   integrity sha512-kJExsp4JCms7ipzg7SJ3y8DwmePaELHxKYtg+tZow+k0znUTf3cb+npgyqm8+ATZOdmfgfydIebPDWM172wfyA==
 
-"@fastify/http-proxy@11.3.0":
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/@fastify/http-proxy/-/http-proxy-11.3.0.tgz#e1d7cfa05ac328e062757d8b2fbc19b57b1e8a6d"
-  integrity sha512-FXFxkdTlXqVI11fqlxmHqOPzIo0elBA60o3bfdh2seD44KWOBBzelzCVgs1OelrxuADCyWUQp2ZxA2wp3mqQMg==
-  dependencies:
-    "@fastify/reply-from" "^12.0.2"
-    fast-querystring "^1.1.2"
-    fastify-plugin "^5.0.1"
-    ws "^8.18.0"
-
 "@fastify/merge-json-schemas@^0.2.0":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz#3aa30d2f0c81a8ac5995b6d94ed4eaa2c3055824"
@@ -270,10 +260,10 @@
     "@fastify/forwarded" "^3.0.0"
     ipaddr.js "^2.1.0"
 
-"@fastify/reply-from@^12.0.2":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@fastify/reply-from/-/reply-from-12.1.0.tgz#e376a2119e4465a84f399e6b2092454268ed1fdb"
-  integrity sha512-5SvMj0NnAAhno/MIv+bErCfzYxcqTueqUxCyub/i+68/CqYWroYg0/p8D0ZhrSQcDigowaKk+MEQSoLjbGwZ+g==
+"@fastify/reply-from@^11.0.0":
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/@fastify/reply-from/-/reply-from-11.0.2.tgz#8b20d504256cbf03da5c5ef74498a026a70e3d9b"
+  integrity sha512-VcHhe01PsHuVX2eVrkoskCs+pwNPgVfOOpwQJnSo3AwIKtISm0VCFB7bycQjHfxAuPYgkrI6ZvYoovdHx4sVMA==
   dependencies:
     "@fastify/error" "^4.0.0"
     end-of-stream "^1.4.4"
@@ -281,7 +271,7 @@
     fast-querystring "^1.1.2"
     fastify-plugin "^5.0.1"
     toad-cache "^3.7.0"
-    undici "^7.0.0"
+    undici "^6.11.1"
 
 "@fastify/type-provider-typebox@5.1.0":
   version "5.1.0"
@@ -6080,10 +6070,10 @@ undici-types@~7.8.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.8.0.tgz#de00b85b710c54122e44fbfd911f8d70174cd294"
   integrity sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==
 
-undici@^7.0.0:
-  version "7.10.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.10.0.tgz#8ae17a976acc6593b13c9ff3342840bea9b24670"
-  integrity sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==
+undici@^6.11.1:
+  version "6.21.3"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.3.tgz#185752ad92c3d0efe7a7d1f6854a50f83b552d7a"
+  integrity sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -6352,11 +6342,6 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
-
-ws@^8.18.0:
-  version "8.18.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.2.tgz#42738b2be57ced85f46154320aabb51ab003705a"
-  integrity sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
This gives us much more flexibility in how we define our routes, and to use conditional logic within the route to e.g. route directly to Tinybird, or to publish to pub/sub