### PR TITLE
Renamed `incoming-event-request` schema to `page-hit-request` schema

### DIFF
--- a/scripts/send-test-request.sh
+++ b/scripts/send-test-request.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Test script to send multiple requests matching the incoming-event-request schema
+# Test script to send multiple requests matching the page-hit-request schema
 # Usage: ./scripts/send-test-request.sh [COUNT]
 
 # Default values

--- a/src/plugins/proxy.ts
+++ b/src/plugins/proxy.ts
@@ -2,7 +2,7 @@ import {FastifyInstance, FastifyRequest, FastifyReply} from 'fastify';
 import fp from 'fastify-plugin';
 import replyFrom from '@fastify/reply-from';
 import {processRequest} from '../services/proxy';
-import {QueryParamsSchema, HeadersSchema, BodySchema, IncomingEventRequest} from '../schemas';
+import {QueryParamsSchema, HeadersSchema, BodySchema, PageHitRequest} from '../schemas';
 
 async function proxyPlugin(fastify: FastifyInstance) {
     // Register reply-from for proxying capabilities
@@ -17,7 +17,7 @@ async function proxyPlugin(fastify: FastifyInstance) {
         }
     }, async (request: FastifyRequest, reply: FastifyReply) => {
         try {
-            await processRequest(request as IncomingEventRequest, reply);
+            await processRequest(request as PageHitRequest, reply);
 
             // Proxy the request to the upstream target
             const upstream = process.env.PROXY_TARGET || 'http://localhost:3000/local-proxy';

--- a/src/schemas/v1/index.ts
+++ b/src/schemas/v1/index.ts
@@ -1,3 +1,3 @@
-export * from './incoming-event-request';
+export * from './page-hit-request';
 export * from './page-hit-raw';
 export * from './page-hit-processed';

--- a/src/schemas/v1/page-hit-request.ts
+++ b/src/schemas/v1/page-hit-request.ts
@@ -73,13 +73,13 @@ export const BodySchema = Type.Object({
 });
 
 // Complete request schema
-export const IncomingEventRequestSchema = Type.Object({
+export const PageHitRequestSchema = Type.Object({
     querystring: QueryParamsSchema,
     headers: HeadersSchema,
     body: BodySchema
 });
 
-export interface IncomingEventRequest extends FastifyRequest {
+export interface PageHitRequest extends FastifyRequest {
     query: Static<typeof QueryParamsSchema>;
     headers: Static<typeof HeadersSchema>;
     body: Static<typeof BodySchema>;

--- a/src/services/proxy/proxy.ts
+++ b/src/services/proxy/proxy.ts
@@ -5,7 +5,7 @@ import {parseUserAgent} from './processors/parse-user-agent';
 import {generateUserSignature} from './processors/user-signature';
 import {publishEvent} from '../events/publisher.js';
 import {TypeCompiler} from '@sinclair/typebox/compiler';
-import {QueryParamsSchema, HeadersSchema, BodySchema, PageHitRaw, IncomingEventRequest} from '../../schemas';
+import {QueryParamsSchema, HeadersSchema, BodySchema, PageHitRaw, PageHitRequest} from '../../schemas';
 import {randomUUID} from 'crypto';
 import validator from '@tryghost/validator';
 
@@ -26,7 +26,7 @@ export const ensureValidEventId = (eventId?: string): string => {
     return randomUUID();
 };
 
-const pageHitRawPayloadFromRequest = (request: IncomingEventRequest): PageHitRaw => {
+const pageHitRawPayloadFromRequest = (request: PageHitRequest): PageHitRaw => {
     return {
         timestamp: request.body.timestamp,
         action: request.body.action,
@@ -52,7 +52,7 @@ const pageHitRawPayloadFromRequest = (request: IncomingEventRequest): PageHitRaw
     };
 };
 
-const publishPageHitRaw = async (request: IncomingEventRequest): Promise<void> => {
+const publishPageHitRaw = async (request: PageHitRequest): Promise<void> => {
     try {
         const topic = process.env.PUBSUB_TOPIC_PAGE_HITS_RAW as string;
         if (topic) {
@@ -78,7 +78,7 @@ const publishPageHitRaw = async (request: IncomingEventRequest): Promise<void> =
 // Called within the HTTP proxy route
 // Eventually will be called on each request pulled from the queue
 export async function processRequest(request: FastifyRequest, reply: FastifyReply): Promise<void> {
-    const validatedRequest = request as IncomingEventRequest;
+    const validatedRequest = request as PageHitRequest;
     validatedRequest.body.payload.event_id = ensureValidEventId(validatedRequest.body.payload.event_id);
     handleSiteUUIDHeader(request);
 

--- a/test/unit/schemas/v1/page-hit-request.test.ts
+++ b/test/unit/schemas/v1/page-hit-request.test.ts
@@ -5,10 +5,10 @@ import {
     HeadersSchema,
     PayloadSchema,
     BodySchema,
-    IncomingEventRequestSchema
+    PageHitRequestSchema
 } from '../../../../src/schemas';
 
-describe('IncomingEventRequestSchema v1', () => {
+describe('PageHitRequestSchema v1', () => {
     describe('QueryParamsSchema', () => {
         it('should validate valid query parameters', () => {
             const validParams = {
@@ -366,7 +366,7 @@ describe('IncomingEventRequestSchema v1', () => {
         });
     });
 
-    describe('IncomingEventRequestSchema', () => {
+    describe('PageHitRequestSchema', () => {
         const validRequest = {
             querystring: {
                 name: 'analytics_events'
@@ -397,7 +397,7 @@ describe('IncomingEventRequestSchema v1', () => {
         };
 
         it('should validate complete valid request', () => {
-            expect(Value.Check(IncomingEventRequestSchema, validRequest)).toBe(true);
+            expect(Value.Check(PageHitRequestSchema, validRequest)).toBe(true);
         });
 
         it('should reject request with invalid query params', () => {
@@ -408,7 +408,7 @@ describe('IncomingEventRequestSchema v1', () => {
                 }
             };
         
-            expect(Value.Check(IncomingEventRequestSchema, invalidRequest)).toBe(false);
+            expect(Value.Check(PageHitRequestSchema, invalidRequest)).toBe(false);
         });
 
         it('should reject request with invalid headers', () => {
@@ -421,7 +421,7 @@ describe('IncomingEventRequestSchema v1', () => {
                 }
             };
         
-            expect(Value.Check(IncomingEventRequestSchema, invalidRequest)).toBe(false);
+            expect(Value.Check(PageHitRequestSchema, invalidRequest)).toBe(false);
         });
 
         it('should reject request with invalid body', () => {
@@ -433,7 +433,7 @@ describe('IncomingEventRequestSchema v1', () => {
                 }
             };
         
-            expect(Value.Check(IncomingEventRequestSchema, invalidRequest)).toBe(false);
+            expect(Value.Check(PageHitRequestSchema, invalidRequest)).toBe(false);
         });
     });
 });


### PR DESCRIPTION
Currently the endpoint we're serving the proxy on is `/tb/web_analytics`. Soon we'll be renaming this to something like `/api/v1/page_hit` to make it more explicit what it's for. In the future we may have other event types with their own endpoints and schemas, so `incoming-event-request` feels far too generic.