### PR TITLE
Added tracker token override if provided in environment

### DIFF
--- a/src/plugins/proxy.ts
+++ b/src/plugins/proxy.ts
@@ -2,7 +2,7 @@ import {FastifyInstance, FastifyRequest, FastifyReply} from 'fastify';
 import fp from 'fastify-plugin';
 import replyFrom from '@fastify/reply-from';
 import {processRequest} from '../services/proxy';
-import {QueryParamsSchema, HeadersSchema, BodySchema, PageHitRequest} from '../schemas';
+import {PageHitRequest, PageHitRequestSchema} from '../schemas';
 
 async function proxyPlugin(fastify: FastifyInstance) {
     // Register reply-from for proxying capabilities
@@ -10,11 +10,7 @@ async function proxyPlugin(fastify: FastifyInstance) {
 
     // Register the analytics proxy with native schema validation
     fastify.post('/tb/web_analytics', {
-        schema: {
-            querystring: QueryParamsSchema,
-            headers: HeadersSchema,
-            body: BodySchema
-        }
+        schema: PageHitRequestSchema
     }, async (request: FastifyRequest, reply: FastifyReply) => {
         try {
             await processRequest(request as PageHitRequest, reply);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1961/remove-the-tracker-token-from-ghost-config-and-tracker-script

We ultimately don't want the tracker token to come from Ghost, since this exposes it in the browser. This commit overrides the tracker token in the request by stripping the existing token from the url query parameters if provided, and adding the `TINYBIRD_TRACKER_TOKEN` from environment as an authorization bearer token.