### PR TITLE
Improved assertions in e2e tests and removed unnecessary tests

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -59,7 +59,7 @@ services:
       - PUBSUB_EMULATOR_HOST=pubsub:8085
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
       - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
-      - TINYBIRD_TRACKER_TOKEN=${TINYBIRD_TRACKER_TOKEN:-}
+      - TINYBIRD_TRACKER_TOKEN=${TINYBIRD_TRACKER_TOKEN:-test-token}
       - PROXY_TARGET=${PROXY_TARGET:-http://fake-tinybird:8080/v0/events}
     networks:
       - dev-network
@@ -97,7 +97,7 @@ services:
       - PUBSUB_TOPIC_PAGE_HITS_RAW=traffic-analytics-page-hits-raw
       - PUBSUB_SUBSCRIPTION_PAGE_HITS_RAW=traffic-analytics-page-hits-raw-sub
       - GOOGLE_APPLICATION_CREDENTIALS=/dev/null
-      - TINYBIRD_TRACKER_TOKEN=${TINYBIRD_TRACKER_TOKEN:-}
+      - TINYBIRD_TRACKER_TOKEN=${TINYBIRD_TRACKER_TOKEN:-test-token}
       - PROXY_TARGET=${PROXY_TARGET:-http://fake-tinybird:8080/v0/events}
     networks:
       - dev-network

--- a/test/utils/wiremock.ts
+++ b/test/utils/wiremock.ts
@@ -174,11 +174,13 @@ export class WireMock {
                 const body = request.request?.body || request.body;
 
                 if (expectedData.token && url) {
-                    matches = matches && url.includes(`token=${expectedData.token}`);
+                    const urlObj = new URL(url, 'http://localhost');
+                    matches = matches && urlObj.searchParams.get('token') === expectedData.token;
                 }
 
                 if (expectedData.name && url) {
-                    matches = matches && url.includes(`name=${expectedData.name}`);
+                    const urlObj = new URL(url, 'http://localhost');
+                    matches = matches && urlObj.searchParams.get('name') === expectedData.name;
                 }
 
                 if (expectedData.bodyContains && body) {


### PR DESCRIPTION
The assertions in the e2e tests were too generic, using `url.includes()` to check the passed query parameters. This isn't specific enough to catch the difference between `analytics_events` and `analytics_events_test`, and was resulting in false failures. This cleans that up, and also adds a default value to the test token in case a token isn't provided via environment variable.