### PR TITLE
Fixed referrer parser drift between proxy and batch mode

### DIFF
--- a/src/schemas/v1/page-hit-raw.ts
+++ b/src/schemas/v1/page-hit-raw.ts
@@ -20,6 +20,8 @@ const ParsedReferrerSchema = Type.Object({
     url: Type.Union([StringSchema, Type.Null()])
 });
 
+export type ParsedReferrer = Static<typeof ParsedReferrerSchema>;
+
 // Payload schema for page hit raw events
 const PayloadSchema = Type.Object({
     event_id: Type.Optional(StringSchema),


### PR DESCRIPTION
The referrer parsing in batch mode didn't quite match up with the referrer parsing in proxy mode. This updates the `transformReferrer` function to match the logic in the `processReferrer` function. This should align the result of the two different pipelines perfectly, at which point we can re-merge them.