### PR TITLE
Removed parsedReferrer and referrer from page-hit-processed schema

### DIFF
--- a/src/schemas/v1/page-hit-processed.ts
+++ b/src/schemas/v1/page-hit-processed.ts
@@ -23,7 +23,6 @@ export const PageHitProcessedSchema = Type.Object({
         post_type: Type.Union([Type.Literal('null'), Type.Literal('post'), Type.Literal('page')]),
         locale: Type.String({minLength: 1}),
         location: Type.Union([Type.String({minLength: 1}), Type.Null()]),
-        referrer: Type.Optional(Type.Union([Type.String(), Type.Null()])),
         pathname: Type.String({minLength: 1}),
         href: Type.String({format: 'uri'}),
         os: Type.String(),
@@ -137,9 +136,7 @@ export async function transformPageHitRawToProcessed(
         pageHitRaw.meta['user-agent']
     );
 
-    const referrer = pageHitRaw.payload.parsedReferrer?.source ?? pageHitRaw.payload.referrer ?? null;
-
-    return {
+    const pageHitProcessed = {
         timestamp: pageHitRaw.timestamp,
         action: pageHitRaw.action,
         version: pageHitRaw.version,
@@ -149,10 +146,11 @@ export async function transformPageHitRawToProcessed(
             event_id: pageHitRaw.payload.event_id ?? crypto.randomUUID(),
             site_uuid: pageHitRaw.site_uuid,
             ...pageHitRaw.payload,
-            referrer,
             ...userAgentData,
             ...referrerData,
             'user-agent': pageHitRaw.meta['user-agent']
         }
     };
+    delete pageHitProcessed.payload.parsedReferrer;
+    return pageHitProcessed;
 }

--- a/test/unit/schemas/v1/page-hit-processed.test.ts
+++ b/test/unit/schemas/v1/page-hit-processed.test.ts
@@ -71,7 +71,6 @@ describe('PageHitProcessedSchema v1', () => {
             post_type: 'post',
             locale: 'en-US',
             location: 'homepage',
-            referrer: 'https://google.com',
             pathname: '/blog/post',
             href: 'https://example.com/blog/post',
             os: 'macos',
@@ -359,6 +358,8 @@ describe('PageHitProcessedSchema v1', () => {
             expect(result.payload.referrerUrl).toBe('https://www.google.com/search?q=ghost+cms');
             expect(result.payload.referrerSource).toBe('Google');
             expect(result.payload.referrerMedium).toBe('search');
+            expect((result.payload as any).referrer).toBeUndefined();
+            expect((result.payload as any).parsedReferrer).toBeUndefined();
             expect(result.payload['user-agent']).toBe(validPageHitRaw.meta['user-agent']);
         
             // Check meta is not included in processed output


### PR DESCRIPTION
The `transformPageHitRawToProcessed` function is now correctly adding the `referrerUrl`, `referrerSource` and `referrerMedium` to the payload, but it was leaving the legacy `referrer` and `parsedReferrer` fields in the object. 

This removes them, to avoid any ambiguity in what the actual referrer info is.