### PR TITLE
Readded parsed referrer to payload

### DIFF
--- a/src/schemas/v1/page-hit-processed.ts
+++ b/src/schemas/v1/page-hit-processed.ts
@@ -28,6 +28,11 @@ export const PageHitProcessedSchema = Type.Object({
         os: Type.String(),
         browser: Type.String(),
         device: Type.String(),
+        parsedReferrer: Type.Optional(Type.Object({
+            url: Type.Union([Type.String(), Type.Null()]),
+            source: Type.Union([Type.String(), Type.Null()]),
+            medium: Type.Union([Type.String(), Type.Null()])
+        })),
         referrerUrl: Type.Optional(Type.Union([Type.String(), Type.Null()])),
         referrerSource: Type.Optional(Type.Union([Type.String(), Type.Null()])),
         referrerMedium: Type.Optional(Type.Union([Type.String(), Type.Null()])),
@@ -151,6 +156,5 @@ export async function transformPageHitRawToProcessed(
             'user-agent': pageHitRaw.meta['user-agent']
         }
     };
-    delete pageHitProcessed.payload.parsedReferrer;
     return pageHitProcessed;
 }

--- a/test/unit/schemas/v1/page-hit-processed.test.ts
+++ b/test/unit/schemas/v1/page-hit-processed.test.ts
@@ -359,7 +359,6 @@ describe('PageHitProcessedSchema v1', () => {
             expect(result.payload.referrerSource).toBe('Google');
             expect(result.payload.referrerMedium).toBe('search');
             expect((result.payload as any).referrer).toBeUndefined();
-            expect((result.payload as any).parsedReferrer).toBeUndefined();
             expect(result.payload['user-agent']).toBe(validPageHitRaw.meta['user-agent']);
         
             // Check meta is not included in processed output


### PR DESCRIPTION
The `parsedReferrer` values are exactly what was sent to the analytics service. Even though we parse the values out into `referrerUrl`, `referrerSource`, `referrerMedium`, it could prove useful to have the original values sent to the service in the payload in the future for debugging. This adds the `parsedReferrer` values back to the payload if they were provided. 