### PR TITLE
Added parsed referrer to payload from proxy

### DIFF
--- a/src/services/proxy/processors/url-referrer.ts
+++ b/src/services/proxy/processors/url-referrer.ts
@@ -25,7 +25,6 @@ export function parseReferrer(request: FastifyRequest): void {
     }
 
     const parsedReferrer = referrerParser.parse(referrerData.url, referrerData.source ?? undefined, referrerData.medium ?? undefined);
-    delete request.body.payload.parsedReferrer;
     request.body.payload.referrerSource = parsedReferrer.referrerSource || null;
     request.body.payload.referrerUrl = parsedReferrer.referrerUrl || null;
     request.body.payload.referrerMedium = parsedReferrer.referrerMedium || null;

--- a/test/unit/services/proxy/processors/url-referrer.test.ts
+++ b/test/unit/services/proxy/processors/url-referrer.test.ts
@@ -55,7 +55,6 @@ describe('Referrer Parser', () => {
         expect(request.body.payload.referrerSource).toBe('Google');
         expect(request.body.payload.referrerUrl).toBe('https://www.google.com/search?q=ghost+cms');
         expect(request.body.payload.referrerMedium).toBe('search');
-        expect(request.body.payload.parsedReferrer).toBeUndefined();
     });
 
     it('should skip processing if referrer header is missing', () => {


### PR DESCRIPTION
ref https://github.com/TryGhost/TrafficAnalytics/commit/71d2a5a775525bb1a2363b164d6b96052ab5c1f2

This does the same thing as the commit above, but for the direct proxy processing pipeline. This way we maintain the parsedReferrer in the payload for debugging, in case we run into any issues with the processing of the referrers in the future.