### PR TITLE
Fixed flaky e2e tests in CI

### DIFF
--- a/.github/actions/lint-and-test/action.yml
+++ b/.github/actions/lint-and-test/action.yml
@@ -39,10 +39,13 @@ runs:
         docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml up -d
         
     - name: Run E2E tests
+      env:
+        PROXY_TARGET: http://fake-tinybird:8080/v0/events
+        COMPOSE_FILE: compose.yml,.github/actions/lint-and-test/compose.ci.yml
       shell: bash
       run: |
         export DOCKER_IMAGE=${{ inputs.docker-image }}
-        docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm e2e-test
+        yarn test:e2e
 
     # Copy coverage report from test container
     - name: Copy coverage report

--- a/.github/actions/lint-and-test/action.yml
+++ b/.github/actions/lint-and-test/action.yml
@@ -41,11 +41,10 @@ runs:
     - name: Run E2E tests
       env:
         PROXY_TARGET: http://fake-tinybird:8080/v0/events
-        COMPOSE_FILE: compose.yml,${{ github.action_path }}/compose.ci.yml
       shell: bash
       run: |
         export DOCKER_IMAGE=${{ inputs.docker-image }}
-        yarn test:e2e
+        docker compose -f compose.yml -f ${{ github.action_path }}/compose.ci.yml run --rm e2e-test
 
     # Copy coverage report from test container
     - name: Copy coverage report

--- a/.github/actions/lint-and-test/action.yml
+++ b/.github/actions/lint-and-test/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Run E2E tests
       env:
         PROXY_TARGET: http://fake-tinybird:8080/v0/events
-        COMPOSE_FILE: compose.yml,.github/actions/lint-and-test/compose.ci.yml
+        COMPOSE_FILE: compose.yml,${{ github.action_path }}/compose.ci.yml
       shell: bash
       run: |
         export DOCKER_IMAGE=${{ inputs.docker-image }}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "_test:integration": "NODE_ENV=testing vitest run --config vitest.config.integration.ts",
     "_test:integration:watch": "NODE_ENV=testing vitest watch --config vitest.config.integration.ts",
     "_test:e2e": "NODE_ENV=testing vitest run test/e2e --coverage=false",
-    "test:e2e": "docker compose up -d --wait && docker compose run --rm e2e-test",
+    "test:e2e": "env PROXY_TARGET=http://fake-tinybird:8080/v0/events sh -c 'docker compose up -d --wait && docker compose run --rm e2e-test'",
     "test:healthchecks": "playwright test",
     "lint": "docker compose --profile testing run --rm test yarn _lint",
     "_lint": "eslint src/ test/ scripts/ *.ts --ext .js,.ts --cache",

--- a/test/utils/wiremock.ts
+++ b/test/utils/wiremock.ts
@@ -212,6 +212,35 @@ export class WireMock {
         }
     }
 
+    // Helper method to wait for a request to be received by WireMock
+    async waitForRequest(criteria: {
+        method?: string;
+        url?: string;
+        urlPattern?: string;
+        headers?: Record<string, string>;
+        token?: string;
+        name?: string;
+        bodyContains?: string;
+    }, options: {
+        timeoutMs?: number;
+        pollIntervalMs?: number;
+    } = {}): Promise<WireMockRequestLog[]> {
+        const {timeoutMs = 10000, pollIntervalMs = 100} = options;
+        const startTime = Date.now();
+
+        while (Date.now() - startTime < timeoutMs) {
+            const requests = await this.verifyTinybirdRequest(criteria);
+            if (requests.length > 0) {
+                return requests;
+            }
+            await new Promise<void>((resolve) => {
+                setTimeout(() => resolve(), pollIntervalMs);
+            });
+        }
+
+        throw new Error(`Timeout waiting for request matching criteria: ${JSON.stringify(criteria)}`);
+    }
+
     // Helper method to get all request details for debugging
     getRequestDetails(request: WireMockRequestLog): any {
         return {


### PR DESCRIPTION
Since switching to batch mode by default in our e2e tests, they've become a bit flakier due to the more variable timing of when the request hits wiremock. These tests had a constant 1 second timeout to wait for the request to be received by wiremock, but even that often wasn't enough, and made the tests unnecessarily slow.

This fixes the flakiness by polling wiremock for the request every 100ms, up to a 10 second timeout. As a result, the tests are more reliable, and often faster as well.