### PR TITLE
Added opt-in pre-commit hooks to run unit tests and linting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+
+# Exit early if pre-commit hooks are disabled
+if [ "$ENABLE_PRE_COMMIT_HOOKS" != "true" ]; then
+  echo "Pre-commit hooks disabled (set ENABLE_PRE_COMMIT_HOOKS=true to enable)"
+  exit 0
+fi
+
+echo "Running pre-commit checks..."
+
+# Run linting
+echo "Running yarn lint..."
+yarn lint
+if [ $? -ne 0 ]; then
+  echo "Linting failed. Please fix the issues before committing."
+  exit 1
+fi
+
+# Run unit tests
+echo "Running yarn test:unit..."
+yarn test:unit
+if [ $? -ne 0 ]; then
+  echo "Unit tests failed. Please fix the issues before committing."
+  exit 1
+fi
+
+echo "Pre-commit checks passed!"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "_test": "yarn _test:types && yarn _test:unit && yarn _test:integration",
     "test:types": "docker compose --profile testing run --rm test yarn _test:types",
     "_test:types": "tsc --noEmit",
-    "test:unit": "docker compose --profile testing run --rm test yarn _test:unit",
+    "test:unit": "docker compose --profile testing run --rm -T test yarn _test:unit",
     "_test:unit": "NODE_ENV=testing vitest run test/unit --coverage",
     "test:unit:watch": "docker compose --profile testing run --rm test yarn _test:unit:watch",
     "_test:unit:watch": "NODE_ENV=testing vitest watch test/unit",
@@ -26,11 +26,12 @@
     "_test:e2e": "NODE_ENV=testing vitest run test/e2e --coverage=false",
     "test:e2e": "env PROXY_TARGET=http://fake-tinybird:8080/v0/events sh -c 'docker compose up -d --wait && docker compose run --rm e2e-test'",
     "test:healthchecks": "playwright test",
-    "lint": "docker compose --profile testing run --rm test yarn _lint",
+    "lint": "docker compose --profile testing run --rm -T test yarn _lint",
     "_lint": "eslint src/ test/ scripts/ *.ts --ext .js,.ts --cache",
     "lint:fix": "docker compose --profile testing run --rm test yarn _lint:fix",
     "_lint:fix": "eslint src/ test/ scripts/ *.ts --ext .js,.ts --cache --fix",
-    "ship": "node scripts/ship.js"
+    "ship": "node scripts/ship.js",
+    "prepare": "husky"
   },
   "files": [
     "dist"
@@ -44,6 +45,7 @@
     "@vitest/coverage-v8": "3.2.4",
     "eslint": "8.57.1",
     "eslint-plugin-ghost": "3.4.3",
+    "husky": "^9.0.0",
     "pino-pretty": "13.0.0",
     "playwright": "1.53.2",
     "supertest": "6.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3917,6 +3917,11 @@ https-proxy-agent@^7.0.1:
     agent-base "^7.1.2"
     debug "4"
 
+husky@^9.0.0:
+  version "9.1.7"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.7.tgz#d46a38035d101b46a70456a850ff4201344c0b2d"
+  integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==
+
 ieee754@^1.1.13:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"


### PR DESCRIPTION
This commit adds a pre-commit hook, which will run `yarn lint` and `yarn test:unit` before allowing commits to go through, which helps prevent wasted time with CI. 

The hooks are opt-in, by setting the `ENABLE_PRE_COMMIT_HOOKS` environment variable in your shell to `true`.