### PR TITLE
Extracted `pageHitRawPayloadFromRequest` transformation into its own file

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import proxyPlugin from './plugins/proxy';
 import {getLoggerConfig} from './utils/logger';
 import {createValidationErrorHandler} from './utils/validation-error-handler';
 import v1Routes from './routes/v1';
+import fp from 'fastify-plugin';
 import replyFrom from '@fastify/reply-from';
 
 const app = fastify({
@@ -19,7 +20,7 @@ const app = fastify({
 app.setErrorHandler(createValidationErrorHandler());
 
 // Register reply-from plugin
-app.register(replyFrom);
+app.register(fp(replyFrom));
 
 // Register CORS plugin
 app.register(corsPlugin);

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,7 +7,6 @@ import proxyPlugin from './plugins/proxy';
 import {getLoggerConfig} from './utils/logger';
 import {createValidationErrorHandler} from './utils/validation-error-handler';
 import v1Routes from './routes/v1';
-import fp from 'fastify-plugin';
 import replyFrom from '@fastify/reply-from';
 
 const app = fastify({
@@ -20,7 +19,7 @@ const app = fastify({
 app.setErrorHandler(createValidationErrorHandler());
 
 // Register reply-from plugin
-app.register(fp(replyFrom));
+app.register(replyFrom);
 
 // Register CORS plugin
 app.register(corsPlugin);

--- a/src/plugins/proxy.ts
+++ b/src/plugins/proxy.ts
@@ -1,34 +1,9 @@
 import {FastifyInstance, FastifyReply} from 'fastify';
 import fp from 'fastify-plugin';
 import {publishEvent} from '../services/events/publisher.js';
-import {PageHitRequestType, PageHitRaw, PageHitRequestQueryParamsSchema, PageHitRequestHeadersSchema, PageHitRequestBodySchema, populateAndTransformPageHitRequest, transformPageHitRawToProcessed} from '../schemas';
+import {PageHitRequestType, PageHitRequestQueryParamsSchema, PageHitRequestHeadersSchema, PageHitRequestBodySchema, populateAndTransformPageHitRequest, transformPageHitRawToProcessed} from '../schemas';
 import type {PageHitRequestQueryParamsType, PageHitRequestHeadersType, PageHitRequestBodyType} from '../schemas';
-import {randomUUID} from 'crypto';
-const pageHitRawPayloadFromRequest = (request: PageHitRequestType): PageHitRaw => {
-    return {
-        timestamp: request.body.timestamp,
-        action: request.body.action,
-        version: request.body.version,
-        site_uuid: request.headers['x-site-uuid'],
-        payload: {
-            event_id: request.body.payload.event_id ?? randomUUID(),
-            member_uuid: request.body.payload.member_uuid,
-            member_status: request.body.payload.member_status,
-            post_uuid: request.body.payload.post_uuid,
-            post_type: request.body.payload.post_type,
-            locale: request.body.payload.locale,
-            location: request.body.payload.location,
-            referrer: request.body.payload.referrer ?? null,
-            parsedReferrer: request.body.payload.parsedReferrer,
-            pathname: request.body.payload.pathname,
-            href: request.body.payload.href
-        },
-        meta: {
-            ip: request.ip,
-            'user-agent': request.headers['user-agent']
-        }
-    };
-};
+import {pageHitRawPayloadFromRequest} from '../transformations/page-hit-transformations.js';
 
 const publishPageHitRaw = async (request: PageHitRequestType): Promise<void> => {
     const topic = process.env.PUBSUB_TOPIC_PAGE_HITS_RAW as string;

--- a/src/transformations/page-hit-transformations.ts
+++ b/src/transformations/page-hit-transformations.ts
@@ -1,0 +1,28 @@
+import {randomUUID} from 'crypto';
+import {PageHitRequestType, PageHitRaw} from '../schemas';
+
+export const pageHitRawPayloadFromRequest = (request: PageHitRequestType): PageHitRaw => {
+    return {
+        timestamp: request.body.timestamp,
+        action: request.body.action,
+        version: request.body.version,
+        site_uuid: request.headers['x-site-uuid'],
+        payload: {
+            event_id: request.body.payload.event_id && request.body.payload.event_id.length > 0 ? request.body.payload.event_id : randomUUID(),
+            member_uuid: request.body.payload.member_uuid,
+            member_status: request.body.payload.member_status,
+            post_uuid: request.body.payload.post_uuid,
+            post_type: request.body.payload.post_type,
+            locale: request.body.payload.locale,
+            location: request.body.payload.location,
+            referrer: request.body.payload.referrer ?? null,
+            parsedReferrer: request.body.payload.parsedReferrer,
+            pathname: request.body.payload.pathname,
+            href: request.body.payload.href
+        },
+        meta: {
+            ip: request.ip,
+            'user-agent': request.headers['user-agent']
+        }
+    };
+};

--- a/test/unit/transformations/page-hit-transformations.test.ts
+++ b/test/unit/transformations/page-hit-transformations.test.ts
@@ -1,0 +1,330 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {pageHitRawPayloadFromRequest} from '../../../src/transformations/page-hit-transformations';
+import {PageHitRequestType} from '../../../src/schemas';
+
+describe('pageHitRawPayloadFromRequest', () => {
+    let mockRequest: PageHitRequestType;
+
+    beforeEach(() => {
+        mockRequest = {
+            ip: '192.168.1.1',
+            headers: {
+                'x-site-uuid': '12345678-1234-1234-1234-123456789012',
+                'content-type': 'application/json',
+                'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36'
+            },
+            body: {
+                timestamp: '2024-01-01T00:00:00.000Z',
+                action: 'page_hit',
+                version: '1',
+                payload: {
+                    event_id: 'test-event-id',
+                    member_uuid: 'member-uuid-123',
+                    member_status: 'free',
+                    post_uuid: 'post-uuid-456',
+                    post_type: 'post',
+                    locale: 'en-US',
+                    location: 'homepage',
+                    referrer: 'https://google.com',
+                    parsedReferrer: {
+                        source: 'google',
+                        medium: 'organic',
+                        url: 'https://google.com'
+                    },
+                    pathname: '/blog/post',
+                    href: 'https://example.com/blog/post'
+                }
+            }
+        } as PageHitRequestType;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should transform request to PageHitRaw with all fields present', () => {
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+
+        expect(result).toEqual({
+            timestamp: '2024-01-01T00:00:00.000Z',
+            action: 'page_hit',
+            version: '1',
+            site_uuid: '12345678-1234-1234-1234-123456789012',
+            payload: {
+                event_id: 'test-event-id',
+                member_uuid: 'member-uuid-123',
+                member_status: 'free',
+                post_uuid: 'post-uuid-456',
+                post_type: 'post',
+                locale: 'en-US',
+                location: 'homepage',
+                referrer: 'https://google.com',
+                parsedReferrer: {
+                    source: 'google',
+                    medium: 'organic',
+                    url: 'https://google.com'
+                },
+                pathname: '/blog/post',
+                href: 'https://example.com/blog/post'
+            },
+            meta: {
+                ip: '192.168.1.1',
+                'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36'
+            }
+        });
+    });
+
+    it('should generate random UUID when event_id is undefined', () => {
+        mockRequest.body.payload.event_id = undefined;
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.event_id).toBeDefined();
+        expect(typeof result.payload.event_id).toBe('string');
+        expect(result.payload.event_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    });
+
+    it('should generate random UUID when event_id is null', () => {
+        mockRequest.body.payload.event_id = null as any;
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.event_id).toBeDefined();
+        expect(typeof result.payload.event_id).toBe('string');
+        expect(result.payload.event_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    });
+
+    it('should generate random UUID when event_id is empty string', () => {
+        mockRequest.body.payload.event_id = '';
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.event_id).toBeDefined();
+        expect(typeof result.payload.event_id).toBe('string');
+        expect(result.payload.event_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    });
+
+    it('should set referrer to null when undefined', () => {
+        mockRequest.body.payload.referrer = undefined;
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.referrer).toBeNull();
+    });
+
+    it('should preserve referrer when it has a value', () => {
+        mockRequest.body.payload.referrer = 'https://facebook.com';
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.referrer).toBe('https://facebook.com');
+    });
+
+    it('should preserve referrer when it is null', () => {
+        mockRequest.body.payload.referrer = null;
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.referrer).toBeNull();
+    });
+
+    it('should handle undefined member_uuid', () => {
+        mockRequest.body.payload.member_uuid = 'undefined';
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.member_uuid).toBe('undefined');
+    });
+
+    it('should handle valid member_uuid', () => {
+        const uuid = '87654321-4321-4321-4321-210987654321';
+        mockRequest.body.payload.member_uuid = uuid;
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.member_uuid).toBe(uuid);
+    });
+
+    it('should handle undefined member_status', () => {
+        mockRequest.body.payload.member_status = 'undefined';
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.member_status).toBe('undefined');
+    });
+
+    it('should handle valid member_status', () => {
+        mockRequest.body.payload.member_status = 'paid';
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.member_status).toBe('paid');
+    });
+
+    it('should handle undefined post_uuid', () => {
+        mockRequest.body.payload.post_uuid = 'undefined';
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.post_uuid).toBe('undefined');
+    });
+
+    it('should handle valid post_uuid', () => {
+        const uuid = '11111111-2222-3333-4444-555555555555';
+        mockRequest.body.payload.post_uuid = uuid;
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.post_uuid).toBe(uuid);
+    });
+
+    it('should handle all post_type values', () => {
+        const postTypes = ['null', 'post', 'page'] as const;
+        
+        postTypes.forEach((postType) => {
+            mockRequest.body.payload.post_type = postType;
+            
+            const result = pageHitRawPayloadFromRequest(mockRequest);
+            
+            expect(result.payload.post_type).toBe(postType);
+        });
+    });
+
+    it('should handle null location', () => {
+        mockRequest.body.payload.location = null;
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.location).toBeNull();
+    });
+
+    it('should handle string location', () => {
+        mockRequest.body.payload.location = 'blog-section';
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.location).toBe('blog-section');
+    });
+
+    it('should handle parsedReferrer with all fields', () => {
+        const parsedReferrer = {
+            source: 'twitter',
+            medium: 'social',
+            url: 'https://twitter.com'
+        };
+        mockRequest.body.payload.parsedReferrer = parsedReferrer;
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.parsedReferrer).toEqual(parsedReferrer);
+    });
+
+    it('should handle parsedReferrer with null values', () => {
+        const parsedReferrer = {
+            source: null,
+            medium: null,
+            url: null
+        };
+        mockRequest.body.payload.parsedReferrer = parsedReferrer;
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.parsedReferrer).toEqual(parsedReferrer);
+    });
+
+    it('should handle parsedReferrer with mixed null and string values', () => {
+        const parsedReferrer = {
+            source: 'reddit',
+            medium: null,
+            url: 'https://reddit.com'
+        };
+        mockRequest.body.payload.parsedReferrer = parsedReferrer;
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.parsedReferrer).toEqual(parsedReferrer);
+    });
+
+    it('should handle undefined parsedReferrer', () => {
+        mockRequest.body.payload.parsedReferrer = undefined;
+        
+        const result = pageHitRawPayloadFromRequest(mockRequest);
+        
+        expect(result.payload.parsedReferrer).toBeUndefined();
+    });
+
+    it('should correctly map meta fields from request', () => {
+        const modifiedRequest = {
+            ...mockRequest,
+            ip: '10.0.0.1',
+            headers: {
+                ...mockRequest.headers,
+                'user-agent': 'Custom User Agent String'
+            }
+        } as PageHitRequestType;
+        
+        const result = pageHitRawPayloadFromRequest(modifiedRequest);
+        
+        expect(result.meta).toEqual({
+            ip: '10.0.0.1',
+            'user-agent': 'Custom User Agent String'
+        });
+    });
+
+    it('should handle complex real-world request', () => {
+        const realWorldRequest = {
+            ip: '203.0.113.42',
+            headers: {
+                'x-site-uuid': 'c7929de8-27d7-404e-b714-0fc774f701e6',
+                'content-type': 'application/json',
+                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.7204.23 Safari/537.36'
+            },
+            body: {
+                timestamp: '2024-03-15T14:30:25.123Z',
+                action: 'page_hit',
+                version: '1',
+                payload: {
+                    event_id: undefined,
+                    member_uuid: 'undefined',
+                    member_status: 'undefined',
+                    post_uuid: 'undefined',
+                    post_type: 'null',
+                    locale: 'en-US',
+                    location: null,
+                    referrer: null,
+                    parsedReferrer: {
+                        source: null,
+                        medium: null,
+                        url: null
+                    },
+                    pathname: '/',
+                    href: 'https://traffic-analytics.ghst.pro/'
+                }
+            }
+        } as PageHitRequestType;
+
+        const result = pageHitRawPayloadFromRequest(realWorldRequest);
+
+        expect(result.timestamp).toBe('2024-03-15T14:30:25.123Z');
+        expect(result.action).toBe('page_hit');
+        expect(result.version).toBe('1');
+        expect(result.site_uuid).toBe('c7929de8-27d7-404e-b714-0fc774f701e6');
+        expect(result.payload.event_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+        expect(result.payload.member_uuid).toBe('undefined');
+        expect(result.payload.member_status).toBe('undefined');
+        expect(result.payload.post_uuid).toBe('undefined');
+        expect(result.payload.post_type).toBe('null');
+        expect(result.payload.locale).toBe('en-US');
+        expect(result.payload.location).toBeNull();
+        expect(result.payload.referrer).toBeNull();
+        expect(result.payload.parsedReferrer).toEqual({
+            source: null,
+            medium: null,
+            url: null
+        });
+        expect(result.payload.pathname).toBe('/');
+        expect(result.payload.href).toBe('https://traffic-analytics.ghst.pro/');
+        expect(result.meta.ip).toBe('203.0.113.42');
+        expect(result.meta['user-agent']).toBe('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.7204.23 Safari/537.36');
+    });
+});


### PR DESCRIPTION
Starting to pull all transformations into a single place in the codebase for easier testing and better separation of concerns. Right now some of these files are sprinkled throughout the proxy plugin itself and the schemas, when really they should be in their own dedicated area.