### PR TITLE
Improved formatting of error logs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,7 @@ import loggingPlugin from './plugins/logging';
 import corsPlugin from './plugins/cors';
 import proxyPlugin from './plugins/proxy';
 import {getLoggerConfig} from './utils/logger';
-import {createValidationErrorHandler} from './utils/validation-error-handler';
+import {errorHandler} from './utils/error-handler';
 import v1Routes from './routes/v1';
 import replyFrom from '@fastify/reply-from';
 
@@ -16,7 +16,7 @@ const app = fastify({
 }).withTypeProvider<TypeBoxTypeProvider>();
 
 // Register global validation error handler
-app.setErrorHandler(createValidationErrorHandler());
+app.setErrorHandler(errorHandler());
 
 // Register reply-from plugin
 app.register(replyFrom);

--- a/src/plugins/logging.ts
+++ b/src/plugins/logging.ts
@@ -14,11 +14,7 @@ async function loggingPlugin(fastify: FastifyInstance) {
             httpRequest: {
                 requestMethod: request.method,
                 requestUrl: request.url,
-                userAgent: request.headers['user-agent'],
-                remoteIp: request.ip,
-                referer: request.headers.referer,
-                protocol: `${request.protocol.toUpperCase()}/${request.raw.httpVersion}`,
-                requestSize: String(request.raw.headers['content-length'] || 0)
+                remoteIp: request.ip
             }
         }, 'incoming request');
     });
@@ -28,14 +24,9 @@ async function loggingPlugin(fastify: FastifyInstance) {
             httpRequest: {
                 requestMethod: request.method,
                 requestUrl: request.url,
-                userAgent: request.headers['user-agent'],
                 remoteIp: request.ip,
-                referer: request.headers.referer,
-                protocol: `${request.protocol.toUpperCase()}/${request.raw.httpVersion}`,
-                requestSize: String(request.raw.headers['content-length'] || 0),
-                responseSize: String(reply.getHeader('content-length') || 0),
                 status: reply.statusCode,
-                latency: `${(reply.elapsedTime / 1000).toFixed(9)}s`
+                latency: `${(reply.elapsedTime / 1000).toFixed(3)}s`
             }
         }, 'request completed');
     });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -38,6 +38,14 @@ export function getLoggerConfig(): LoggerOptions {
                     return {
                         statusCode: reply.statusCode
                     };
+                },
+                err(error: Error) {
+                    return {
+                        message: error.message,
+                        name: error.name,
+                        code: 'code' in error ? (error as Error & {code: string}).code : undefined,
+                        stack: error.stack
+                    };
                 }
             }
         };
@@ -47,7 +55,18 @@ export function getLoggerConfig(): LoggerOptions {
     const gcpConfig = createGcpLoggingPinoConfig();
     return {
         ...gcpConfig,
-        level: process.env.LOG_LEVEL || 'info'
+        level: process.env.LOG_LEVEL || 'info',
+        serializers: {
+            ...gcpConfig.serializers,
+            err(error: Error) {
+                return {
+                    message: error.message,
+                    name: error.name,
+                    code: 'code' in error ? (error as Error & {code: string}).code : undefined,
+                    stack: error.stack
+                };
+            }
+        }
     };
 }
 

--- a/test/integration/error-logging.test.ts
+++ b/test/integration/error-logging.test.ts
@@ -1,0 +1,153 @@
+import {describe, it, expect, beforeEach, vi} from 'vitest';
+import {FastifyError} from 'fastify';
+import {errorHandler} from '../../src/utils/error-handler';
+
+// Mock the logger methods
+const mockWarn = vi.fn();
+const mockError = vi.fn();
+
+const mockRequest = {
+    method: 'POST',
+    url: '/test-endpoint',
+    ip: '127.0.0.1',
+    headers: {
+        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+        referer: 'https://example.com/dashboard'
+    },
+    query: {page: '1', limit: '10'},
+    body: {name: 'John Doe', email: 'john@example.com'}
+} as any;
+
+const mockReply = {
+    log: {
+        warn: mockWarn,
+        error: mockError
+    },
+    status: vi.fn().mockReturnThis(),
+    send: vi.fn()
+} as any;
+
+describe('Error Logging', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should log validation errors with stack traces', () => {
+        const validationError = {
+            statusCode: 400,
+            code: 'FST_ERR_VALIDATION',
+            validation: [
+                {instancePath: '/name', schemaPath: '#/properties/name/type', keyword: 'type', params: {type: 'string'}, message: 'must be string'}
+            ],
+            validationContext: 'querystring',
+            message: 'querystring must have required property "name"',
+            name: 'FastifyError',
+            stack: `FastifyError: querystring must have required property "name"
+    at Object.validateInput (/app/node_modules/fastify/lib/validation.js:123:45)
+    at preValidation (/app/node_modules/fastify/lib/hooks.js:234:56)
+    at processTicksAndRejections (node:internal/process/task_queues.js:95:5)`
+        } as FastifyError;
+
+        const handler = errorHandler();
+        handler(validationError, mockRequest, mockReply);
+
+        // Verify validation error was logged with stack trace and useful request data
+        expect(mockWarn).toHaveBeenCalledWith(
+            expect.objectContaining({
+                err: expect.objectContaining({
+                    message: 'querystring must have required property "name"',
+                    name: 'FastifyError',
+                    code: 'FST_ERR_VALIDATION',
+                    stack: expect.stringContaining('at Object.validateInput'),
+                    validation: expect.any(Array)
+                }),
+                httpRequest: expect.objectContaining({
+                    userAgent: expect.any(String),
+                    referer: expect.any(String)
+                }),
+                query: expect.any(Object),
+                requestBody: expect.any(Object),
+                type: 'validation_error'
+            }),
+            'Schema validation failed'
+        );
+
+        // Verify the logged data structure
+        const loggedData = mockWarn.mock.calls[0][0];
+        expect(loggedData).toHaveProperty('err.stack');
+        expect(loggedData).toHaveProperty('err.code');
+        expect(loggedData).toHaveProperty('query');
+        expect(loggedData).toHaveProperty('requestBody');
+    });
+
+    it('should log unhandled errors with stack traces', () => {
+        const unhandledError = {
+            statusCode: 500,
+            code: 'DATABASE_ERROR',
+            message: 'Database connection failed',
+            name: 'DatabaseError',
+            stack: `DatabaseError: Database connection failed
+    at DatabaseService.connect (/app/src/services/database.ts:45:23)
+    at Object.handler (/app/src/routes/users.ts:12:34)
+    at processTicksAndRejections (node:internal/process/task_queues.js:95:5)`
+        } as FastifyError;
+
+        const handler = errorHandler();
+        handler(unhandledError, mockRequest, mockReply);
+
+        // Verify unhandled error was logged with stack trace and useful request data
+        expect(mockError).toHaveBeenCalledWith(
+            expect.objectContaining({
+                err: expect.objectContaining({
+                    message: 'Database connection failed',
+                    name: 'DatabaseError',
+                    code: 'DATABASE_ERROR',
+                    stack: expect.stringContaining('at DatabaseService.connect'),
+                    statusCode: 500
+                }),
+                httpRequest: expect.objectContaining({
+                    userAgent: expect.any(String),
+                    referer: expect.any(String)
+                }),
+                query: expect.any(Object),
+                requestBody: expect.any(Object),
+                type: 'unhandled_error'
+            }),
+            'Database connection failed'
+        );
+
+        // Verify the logged data structure
+        const loggedData = mockError.mock.calls[0][0];
+        expect(loggedData).toHaveProperty('err.stack');
+        expect(loggedData).toHaveProperty('err.code');
+        expect(loggedData).toHaveProperty('query');
+        expect(loggedData).toHaveProperty('requestBody');
+    });
+
+    it('should demonstrate the difference - old vs new logging', () => {
+        const error = {
+            statusCode: 500,
+            code: 'SERVICE_ERROR',
+            message: 'User service failed to process request',
+            name: 'ServiceError',
+            stack: `ServiceError: User service failed to process request
+    at UserService.processUser (/app/src/services/user-service.ts:89:15)
+    at UserController.createUser (/app/src/controllers/user-controller.ts:34:22)
+    at Object.handler (/app/src/routes/users.ts:18:45)
+    at processTicksAndRejections (node:internal/process/task_queues.js:95:5)`
+        } as FastifyError;
+
+        const handler = errorHandler();
+        handler(error, mockRequest, mockReply);
+
+        // Verify the new logging is cleaner and includes stack trace
+        const loggedData = mockError.mock.calls[0][0];
+        expect(loggedData).toHaveProperty('err.stack');
+        expect(loggedData).toHaveProperty('err.code');
+        expect(loggedData).toHaveProperty('query');
+        expect(loggedData).toHaveProperty('requestBody');
+        expect(loggedData).toHaveProperty('httpRequest.userAgent');
+        expect(loggedData).toHaveProperty('httpRequest.referer');
+        expect(loggedData).toHaveProperty('type', 'unhandled_error');
+    });
+});


### PR DESCRIPTION
Our error logs include a lot of unnecessary information, and are missing a lot of really useful information like stack traces. This improves the formatting of our error logs, which should make them a lot easier to debug. 