### PR TITLE
Updated healthchecks to be compatible with new versioned endpoint

### DIFF
--- a/test/healthchecks/ghost-site.spec.ts
+++ b/test/healthchecks/ghost-site.spec.ts
@@ -3,14 +3,14 @@ import {test, expect} from './fixtures';
 test.describe('Ghost site healthcheck', () => {
     test('should make analytics request with 202 response', async ({page, baseURL}) => {
         // Wait for the analytics request
-        const analyticsRequestPromise = page.waitForRequest('**/.ghost/analytics/tb/web_analytics**');
-        const analyticsResponsePromise = page.waitForResponse('**/.ghost/analytics/tb/web_analytics**');
+        const analyticsRequestPromise = page.waitForRequest('**/.ghost/analytics/**');
+        const analyticsResponsePromise = page.waitForResponse('**/.ghost/analytics/**');
         
         await page.goto(baseURL!);
         
         // Verify the analytics request was made
         const request = await analyticsRequestPromise;
-        expect(request.url()).toContain('/.ghost/analytics/tb/web_analytics');
+        expect(request.url()).toContain('/.ghost/analytics/');
         
         // Verify the response status is 202
         const response = await analyticsResponsePromise;


### PR DESCRIPTION
After changing Ghost's configuration to use the new `/api/v1/page_hit` endpoints, our healthchecks started failing because they are specifically looking for the request to `/.ghost/analytics/tb/web_analytics`, and those requests are no longer being made. 

This updates the healthchecks to just look for any request to `/.ghost/analytics/**` for now so they will pass for either endpoint. I'll circle back and make these more specific after the change is fully rolled out. 