### PR TITLE
Disable renovate automerge for all packages during code freeze

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,11 @@
   ],
   "packageRules": [
     {
+      "description": "Temporarily disable automerge for all packages",
+      "matchPackagePatterns": ["*"],
+      "automerge": false
+    },
+    {
       "description": "Pin ua-parser-js to <2.0.0 to remain on the MIT license. Versions 2.0.0+ switched to AGPL, which is not compatible with our MIT license.",
       "matchPackageNames": ["ua-parser-js"],
       "allowedVersions": "<2.0.0"


### PR DESCRIPTION
To avoid any regressions between QA complete and 6.0 launch, this prevents renovate from automatically merging any dependency updates. We will undo this change next week.