### PR TITLE
Improved structured logging in the batch worker

### DIFF
--- a/src/services/batch-worker/BatchWorker.ts
+++ b/src/services/batch-worker/BatchWorker.ts
@@ -96,15 +96,9 @@ class BatchWorker {
     }
 
     private async parseMessage(message: Message) {
-        try {
-            const messageData = message.data.toString();
-            const json = JSON.parse(messageData);
-            return Value.Parse(PageHitRawSchema, json);
-        } catch (error) {
-            logger.error({messageData: message.data.toString(), err: error}, 'Worker unable to parse message. Nacking message...');
-            message.nack();
-            throw error;
-        }
+        const messageData = message.data.toString();
+        const json = JSON.parse(messageData);
+        return Value.Parse(PageHitRawSchema, json);
     }
 
     private async transformMessage(pageHitRaw: PageHitRaw) {

--- a/src/services/batch-worker/BatchWorker.ts
+++ b/src/services/batch-worker/BatchWorker.ts
@@ -90,7 +90,13 @@ class BatchWorker {
                 await this.flushBatch();
             }
         } catch (error) {
-            logger.error({messageData: message.data.toString(), err: error}, 'Worker unable to process message. Nacking message...');
+            let messageData;
+            try {
+                messageData = JSON.parse(message.data.toString());
+            } catch (_error) {
+                messageData = message.data.toString();
+            }
+            logger.error({event: 'WorkerFailedToProcessMessageError', messageId: message.id, messageData, err: error});
             message.nack();
         }
     }

--- a/src/services/batch-worker/BatchWorker.ts
+++ b/src/services/batch-worker/BatchWorker.ts
@@ -112,12 +112,7 @@ class BatchWorker {
     }
 
     private async transformMessage(pageHitRaw: PageHitRaw) {
-        try {
-            return await transformPageHitRawToProcessed(pageHitRaw);
-        } catch (error) {
-            logger.error({pageHitRaw, err: error}, 'Worker unable to transform message');
-            throw error;
-        }
+        return await transformPageHitRawToProcessed(pageHitRaw);
     }
 
     private async flushBatch() {

--- a/test/unit/services/batch-worker/batch-worker.test.ts
+++ b/test/unit/services/batch-worker/batch-worker.test.ts
@@ -190,18 +190,49 @@ describe('BatchWorker', () => {
 
             await (batchWorker as any).handleMessage(mockMessage);
 
+            expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({
+                event: 'WorkerFailedToProcessMessageError', 
+                messageId: mockMessage.id, 
+                messageData: invalidJson, 
+                err: expect.any(Object)
+            }));
+
             expectMessageNacked(mockMessage);
         });
 
         it('should handle invalid schema and nack message', async () => {
-            const invalidData = {
-                timestamp: 'invalid-timestamp',
-                action: 'invalid-action',
-                version: '2'
+            const invalidPageHitRawWithEmptyUserAgent = {
+                timestamp: '2024-01-01T12:00:00.000Z',
+                action: 'page_hit',
+                version: '1',
+                site_uuid: '550e8400-e29b-41d4-a716-446655440000',
+                payload: {
+                    event_id: '123e4567-e89b-12d3-a456-426614174000',
+                    member_uuid: 'undefined',
+                    member_status: 'undefined',
+                    post_uuid: 'undefined',
+                    post_type: 'null',
+                    locale: 'en-US',
+                    location: 'New York',
+                    referrer: 'https://example.com',
+                    pathname: '/blog/post',
+                    href: 'https://mysite.com/blog/post'
+                },
+                meta: {
+                    ip: '192.168.1.1',
+                    'user-agent': ''
+                }
             };
-            const mockMessage = createMockMessage(JSON.stringify(invalidData));
+            const mockMessage = createMockMessage(JSON.stringify(invalidPageHitRawWithEmptyUserAgent));
 
             await (batchWorker as any).handleMessage(mockMessage);
+
+            expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({
+                event: 'WorkerFailedToProcessMessageError', 
+                messageId: mockMessage.id, 
+                messageData: invalidPageHitRawWithEmptyUserAgent,
+                err: expect.any(Object)
+            }));
 
             expectMessageNacked(mockMessage);
         });

--- a/test/unit/services/batch-worker/batch-worker.test.ts
+++ b/test/unit/services/batch-worker/batch-worker.test.ts
@@ -135,6 +135,9 @@ describe('BatchWorker', () => {
             // Should log debug message for adding to batch
             expect(logger.info).toHaveBeenCalledWith(
                 expect.objectContaining({
+                    event: 'WorkerProcessedMessage',
+                    messageId: mockMessage.id,
+                    messageData: validPageHitRawData,
                     pageHitProcessed: expect.objectContaining({
                         timestamp: validPageHitRawData.timestamp,
                         action: validPageHitRawData.action,
@@ -158,8 +161,7 @@ describe('BatchWorker', () => {
                             device: expect.any(String)
                         })
                     })
-                }),
-                'Worker processed message and added to batch'
+                })
             );
             
             // Message should not be acked yet
@@ -348,6 +350,8 @@ describe('BatchWorker', () => {
             expect(logger.info).toHaveBeenCalledWith(
                 expect.objectContaining({
                     event: 'BotEventFiltered',
+                    messageId: mockMessage.id,
+                    messageData: botData,
                     pageHitProcessed: expect.objectContaining({
                         payload: expect.objectContaining({
                             device: 'bot'


### PR DESCRIPTION
Our current logging in the batch worker doesn't fully take advantage of structured logging, which makes it difficult to debug when messages fail to be processed for whatever reason. This commit doesn't change any behavior apart from logging:

- Removes duplicate error logs when a message fails to be parsed successfully
- Adds an `event` field to all relevant logs to make them more searchable
- Adds the pub/sub message ID and message data to all relevant logs