### PR TITLE
Fixed validation incorrectly passing with whitespace-only user agent

### DIFF
--- a/src/schemas/v1/page-hit-request.ts
+++ b/src/schemas/v1/page-hit-request.ts
@@ -5,7 +5,10 @@ import {FastifyRequest} from 'fastify';
 
 // Common types
 const StringSchema = Type.String();
-const NonEmptyStringSchema = Type.String({minLength: 1});
+const NonEmptyStringSchema = Type.String({
+    minLength: 1,
+    pattern: '^.*\\S.*$' // At least one non-whitespace character
+});
 const UUIDSchema = Type.String({format: 'uuid'});
 const ISO8601DateTimeSchema = Type.String({
     format: 'date-time'
@@ -47,7 +50,7 @@ export type PageHitRequestQueryParamsType = Static<typeof PageHitRequestQueryPar
 export const PageHitRequestHeadersSchema = Type.Object({
     'x-site-uuid': UUIDSchema,
     'content-type': ContentTypeSchema,
-    'user-agent': StringSchema,
+    'user-agent': NonEmptyStringSchema,
     referer: Type.Optional(StringSchema)
 }, {
     additionalProperties: Type.Union([StringSchema, Type.Array(StringSchema)])

--- a/test/integration/app.test.ts
+++ b/test/integration/app.test.ts
@@ -259,6 +259,20 @@ describe('Fastify App', () => {
                     });
             });
 
+            it('should reject requests with only whitespace in the user-agent header', async function () {
+                await request(proxyServer)
+                    .post(path)
+                    .query({token: 'abc123', name: 'analytics_events'})
+                    .set('Content-Type', 'application/json')
+                    .set('x-site-uuid', '940b73e9-4952-4752-b23d-9486f999c47e')
+                    .set('User-Agent', ' ')
+                    .send(eventPayload)
+                    .expect(400)
+                    .expect(function (res) {
+                        assert.ok(res.body.message.includes('headers/user-agent must NOT have fewer than 1 characters'));
+                    });
+            });
+
             it('should return 404 for GET requests', async function () {
                 await request(proxyServer)
                     .get(path)


### PR DESCRIPTION
Currently a request with a whitespace-only user agent header, i.e. `User-Agent:  ` can pass validation. This causes errors downstream in the `BatchWorker`, which ends up trying to process a message with an empty user agent. 

This fixes the problem with the request validation, which should prevent these invalid events from reaching the `BatchWorker`. It does not yet improve the handling in the `BatchWorker` itself.