### PR TITLE
Improved support for running locally with Ghost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,4 @@ COPY . .
 
 RUN yarn build
 
-RUN chmod +x ./scripts/entrypoint.sh
-
-ENTRYPOINT ["./scripts/entrypoint.sh"]
-
 CMD ["node", "--enable-source-maps", "dist/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,8 @@ COPY . .
 
 RUN yarn build
 
+RUN chmod +x ./scripts/entrypoint.sh
+
+ENTRYPOINT ["./scripts/entrypoint.sh"]
+
 CMD ["node", "--enable-source-maps", "dist/server.js"]

--- a/compose.ghost.yml
+++ b/compose.ghost.yml
@@ -1,0 +1,27 @@
+# Override file to allow running Ghost locally against the analytics service in this repo
+# Usage: `docker compose -f compose.ghost.yml -f compose.yml up`
+
+services:
+  analytics-service:
+    volumes:
+      - ghost_shared-config:/mnt/shared-config:ro
+    networks:
+      - ghost_default
+  worker:
+    volumes:
+      - ghost_shared-config:/mnt/shared-config:ro
+    networks:
+      - ghost_default
+  analytics-service-proxy:
+    volumes:
+      - ghost_shared-config:/mnt/shared-config:ro
+    networks:
+      - ghost_default
+
+volumes:
+  ghost_shared-config:
+    external: true
+
+networks:
+  ghost_default:
+    external: true

--- a/compose.yml
+++ b/compose.yml
@@ -6,6 +6,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    entrypoint: ["/app/scripts/entrypoint.sh"]
     command: ["yarn","tsx", "watch", "server.ts"]
     ports:
       - ${ANALYTICS_PORT:-3000}:3000
@@ -42,6 +43,7 @@ services:
   worker:
     image: local/traffic-analytics:development
     pull_policy: never
+    entrypoint: ["/app/scripts/entrypoint.sh"]
     command: ["yarn", "tsx", "watch", "server.ts"]
     ports:
       - ${WORKER_PORT:-3001}:3000
@@ -113,7 +115,7 @@ services:
         condition: service_healthy
       fake-tinybird:
         condition: service_healthy
-  
+
   firestore:
     image: google/cloud-sdk:emulators
     command: ["/app/firestore-wrapper.sh"]

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "yarn dev:batch",
     "dev:proxy": "docker compose up -d --wait && docker compose up analytics-service-proxy",
     "dev:batch": "docker compose up -d --wait && docker compose up analytics-service worker",
+    "dev:ghost": "docker compose up -d --wait && docker compose -f compose.yml -f compose.ghost.yml -f compose.override.yml up analytics-service worker",
     "start": "node --enable-source-maps dist/server.js",
     "start:worker": "WORKER_MODE=true node --enable-source-maps dist/server.js",
     "pretest": "yarn build",

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Entrypoint script for the Analytics service in compose.yml
+## This script configures the environment for the Analytics service to use Tinybird local.
+## It depends on the `tb-cli` service, which creates the `.env` file, which is mounted
+## into the Analytics service container at `/app/.env`.
+
+# Note: the analytics service's container is based on alpine, hence `sh` instead of `bash`.
+set -eu
+
+# Initialize child process variable
+child=""
+
+# Handle shutdown signals gracefully.
+_term() {
+    echo "Caught SIGTERM/SIGINT signal, shutting down gracefully..."
+    if [ -n "$child" ]; then
+        kill -TERM "$child" 2>/dev/null || true
+        wait "$child" 2>/dev/null || true
+    fi
+    exit 0
+}
+
+# Set up signal handlers (POSIX-compliant signal names)
+trap _term TERM INT
+
+# Set the TINYBIRD_TRACKER_TOKEN environment variable from the .env file
+# This file is created by the `tb-cli` service and mounted into the Analytics service container
+if [ -f /mnt/shared-config/.env.tinybird ]; then
+    . /mnt/shared-config/.env.tinybird
+    if [ -n "${TINYBIRD_TRACKER_TOKEN:-}" ]; then
+        export TINYBIRD_TRACKER_TOKEN="$TINYBIRD_TRACKER_TOKEN"
+        export PROXY_TARGET="http://tinybird-local:7181"
+        echo "Tinybird tracker token configured successfully"
+    else
+        echo "WARNING: TINYBIRD_TRACKER_TOKEN not found in /mnt/shared-config/.env.tinybird" >&2
+    fi
+else
+    echo "WARNING: /mnt/shared-config/.env.tinybird file not found - Tinybird tracking may not work" >&2
+fi
+
+# Start the process in the background
+"$@" &
+child=$!
+
+# Wait for the child process
+wait "$child"


### PR DESCRIPTION
This makes it much easier to run Ghost locally against your local clone of the Analytics Service. 

Related PR in Ghost: https://github.com/TryGhost/Ghost/pull/24731

Key changes:
- Adds a `compose.ghost.yml` file, which attaches the analytics service to the Ghost project's default network and mounts the `shared-config` volume at `/mnt/shared-config`
- Adds a `yarn dev:ghost` command that extends the base `compose.yml` with `compose.ghost.yml`
- Adds an entrypoint to the analytics service that gets the `TINYBIRD_TRACKER_TOKEN` from the volume on boot