### PR TITLE
Updated target in compose.yml to use development build

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -6,6 +6,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: base
     entrypoint: ["/app/scripts/entrypoint.sh"]
     command: ["yarn","tsx", "watch", "server.ts"]
     ports:
@@ -86,6 +87,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: base
     command: ["yarn", "tsx", "watch", "server.ts"]
     ports:
       - 4000:3000


### PR DESCRIPTION
The `compose.yml` file didn't specify a build target, so it was defaulting to the last one (production). The production build doesn't have all the necessary dependencies for local development, so `yarn dev` was failing. This sets the target properly, so when running `docker compose *` commands, it will use the development image instead of the production image.