### PR TITLE
Added support for utm params in referrer payload

### DIFF
--- a/src/schemas/v1/page-hit-request.ts
+++ b/src/schemas/v1/page-hit-request.ts
@@ -62,7 +62,12 @@ export type PageHitRequestHeadersType = Static<typeof PageHitRequestHeadersSchem
 const ParsedReferrerSchema = Type.Object({
     source: Type.Union([StringSchema, Type.Null()]),
     medium: Type.Union([StringSchema, Type.Null()]),
-    url: Type.Union([StringSchema, Type.Null()])
+    url: Type.Union([StringSchema, Type.Null()]),
+    utmSource: Type.Optional(Type.Union([StringSchema, Type.Null()])),
+    utmMedium: Type.Optional(Type.Union([StringSchema, Type.Null()])),
+    utmTerm: Type.Optional(Type.Union([StringSchema, Type.Null()])),
+    utmCampaign: Type.Optional(Type.Union([StringSchema, Type.Null()])),
+    utmContent: Type.Optional(Type.Union([StringSchema, Type.Null()]))
 });
 
 // Payload schema
@@ -127,7 +132,12 @@ export const PageHitRequestPayloadDefaults = {
     parsedReferrer: {
         source: null,
         medium: null,
-        url: null
+        url: null,
+        utmSource: null,
+        utmMedium: null,
+        utmTerm: null,
+        utmCampaign: null,
+        utmContent: null
     },
     pathname: '',
     href: '',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,11 @@ export interface Payload {
         source: string | null;
         medium: string | null;
         url: string | null;
+        utmSource?: string | null;
+        utmMedium?: string | null;
+        utmTerm?: string | null;
+        utmCampaign?: string | null;
+        utmContent?: string | null;
     };
     pathname: string;
     href: string;
@@ -24,6 +29,11 @@ export interface Payload {
     referrerSource?: string | null;
     referrerUrl?: string | null;
     referrerMedium?: string | null;
+    utmSource?: string | null;
+    utmMedium?: string | null;
+    utmTerm?: string | null;
+    utmCampaign?: string | null;
+    utmContent?: string | null;
     meta?: {
         userSignature?: string;
         [key: string]: unknown;

--- a/test/unit/schemas/v1/page-hit-request.test.ts
+++ b/test/unit/schemas/v1/page-hit-request.test.ts
@@ -350,6 +350,73 @@ describe('PageHitRequestSchema v1', () => {
             expect(Value.Check(PageHitRequestPayloadSchema, payloadWithIncompleteParsedReferrer)).toBe(false);
         });
 
+        it('should validate parsedReferrer with UTM parameters', () => {
+            const payloadWithUTMParams = {
+                ...validPayload,
+                parsedReferrer: {
+                    source: 'newsletter',
+                    medium: 'email',
+                    url: 'https://example.com',
+                    utmSource: 'newsletter',
+                    utmMedium: 'email',
+                    utmCampaign: 'summer-sale',
+                    utmTerm: 'ghost-cms',
+                    utmContent: 'header-link'
+                }
+            };
+
+            expect(Value.Check(PageHitRequestPayloadSchema, payloadWithUTMParams)).toBe(true);
+        });
+
+        it('should validate parsedReferrer with partial UTM parameters', () => {
+            const payloadWithPartialUTM = {
+                ...validPayload,
+                parsedReferrer: {
+                    source: 'google',
+                    medium: 'cpc',
+                    url: 'https://example.com',
+                    utmSource: 'google',
+                    utmMedium: 'cpc',
+                    utmCampaign: 'brand-awareness'
+                    // utmTerm and utmContent are omitted
+                }
+            };
+
+            expect(Value.Check(PageHitRequestPayloadSchema, payloadWithPartialUTM)).toBe(true);
+        });
+
+        it('should validate parsedReferrer with null UTM parameters', () => {
+            const payloadWithNullUTM = {
+                ...validPayload,
+                parsedReferrer: {
+                    source: 'direct',
+                    medium: null,
+                    url: 'https://example.com',
+                    utmSource: null,
+                    utmMedium: null,
+                    utmCampaign: null,
+                    utmTerm: null,
+                    utmContent: null
+                }
+            };
+
+            expect(Value.Check(PageHitRequestPayloadSchema, payloadWithNullUTM)).toBe(true);
+        });
+
+        it('should validate parsedReferrer without UTM parameters', () => {
+            const payloadWithoutUTM = {
+                ...validPayload,
+                parsedReferrer: {
+                    source: 'organic',
+                    medium: 'search',
+                    url: 'https://google.com'
+                    // no UTM fields
+                }
+            };
+
+            expect(Value.Check(PageHitRequestPayloadSchema, payloadWithoutUTM)).toBe(true);
+        });
+
         it('should reject parsedReferrer with invalid field types', () => {
             const payloadWithInvalidParsedReferrer = {
                 ...validPayload,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-2561/
- added utm params to referrer payload
- added utm params to schema
- updated tests

Added optional UTM params to the parsed referrer payload. These are intended to be used for attribution, just like the rest of the 'referrer' fields.

To be clear, this does not add passing along the data - it only updates the schema/supports it.