### PR TITLE
Improve batch worker error log serialization and test assertions

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,5 +2,14 @@ module.exports = {
     plugins: ['ghost'],
     extends: [
         'plugin:ghost/ts'
-    ]
+    ],
+    rules: {
+        'no-restricted-syntax': [
+            'error',
+            {
+                selector: 'CallExpression[callee.object.name=\'logger\'] > ObjectExpression > Property[key.name=\'error\']',
+                message: 'Use `err` instead of `error` — Pino only serializes errors on the `err` key.'
+            }
+        ]
+    }
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,6 +9,10 @@ module.exports = {
             {
                 selector: 'CallExpression[callee.object.name=\'logger\'] > ObjectExpression > Property[key.name=\'error\']',
                 message: 'Use `err` instead of `error` — Pino only serializes errors on the `err` key.'
+            },
+            {
+                selector: 'CallExpression[callee.object.property.name=\'log\'] > ObjectExpression > Property[key.name=\'error\']',
+                message: 'Use `err` instead of `error` — Pino only serializes errors on the `err` key.'
             }
         ]
     }

--- a/src/handlers/page-hit-handlers.ts
+++ b/src/handlers/page-hit-handlers.ts
@@ -10,14 +10,10 @@ export const handlePageHitRequestStrategyBatch = async (request: PageHitRequestT
     try {
         await publishPageHitRaw(request, payload);
         reply.status(202).send({message: 'Page hit event received'});
-    } catch (error) {
+    } catch (err) {
         request.log.error({
             event: 'PageHitPublishFailed',
-            error: error instanceof Error ? {
-                message: error.message,
-                stack: error.stack,
-                name: error.name
-            } : error,
+            err,
             payload,
             httpRequest: {
                 requestMethod: request.method,
@@ -80,11 +76,7 @@ export const handlePageHitRequestStrategyInline = async (request: PageHitRequest
             const unwrappedError = 'error' in error ? error.error : error;
             replyInstance.log.error({
                 event: 'ProxyError',
-                error: {
-                    message: unwrappedError.message,
-                    stack: unwrappedError.stack,
-                    name: unwrappedError.name
-                },
+                err: unwrappedError,
                 httpRequest: {
                     requestMethod: replyInstance.request.method,
                     requestUrl: replyInstance.request.url,
@@ -114,14 +106,10 @@ export const pageHitRequestHandler = async (request: FastifyRequest<{
         } else {
             await handlePageHitRequestStrategyInline(request, reply);
         }
-    } catch (error) {
+    } catch (err) {
         reply.log.error({
             event: 'RequestProcessingError',
-            error: error instanceof Error ? {
-                message: error.message,
-                stack: error.stack,
-                name: error.name
-            } : error,
+            err,
             httpRequest: {
                 requestMethod: request.method,
                 requestUrl: request.url,

--- a/src/plugins/hmac-validation.ts
+++ b/src/plugins/hmac-validation.ts
@@ -33,7 +33,7 @@ async function hmacValidationPlugin(fastify: FastifyInstance) {
                     method: request.method,
                     ip: request.ip,
                     userAgent: request.headers['user-agent'],
-                    error: validationResult.error,
+                    reason: validationResult.error,
                     type: 'security_validation_error',
                     logOnlyMode
                 });
@@ -64,14 +64,10 @@ async function hmacValidationPlugin(fastify: FastifyInstance) {
                 method: request.method,
                 ip: request.ip
             });
-        } catch (error) {
+        } catch (err) {
             request.log.error({
                 event: 'HmacValidationError',
-                error: error instanceof Error ? {
-                    message: error.message,
-                    stack: error.stack,
-                    name: error.name
-                } : error,
+                err,
                 url: request.url,
                 method: request.method,
                 ip: request.ip,

--- a/src/services/batch-worker/BatchWorker.ts
+++ b/src/services/batch-worker/BatchWorker.ts
@@ -100,12 +100,12 @@ class BatchWorker {
             if (this.batch.length >= this.batchSize) {
                 await this.flushBatch();
             }
-        } catch (error) {
+        } catch (err) {
             logger.error({
                 event: 'WorkerMessageProcessingFailed',
                 messageId: message.id,
                 messageData: this.getMessageData(message),
-                err: error
+                err
             });
             message.nack();
         }
@@ -116,12 +116,12 @@ class BatchWorker {
             const messageData = message.data.toString();
             const parsedMessageData = JSON.parse(messageData);
             return Value.Parse(PageHitRawSchema, parsedMessageData);
-        } catch (error) {
+        } catch (err) {
             logger.error({
                 event: 'WorkerMessageParsingFailed',
                 messageId: message.id,
                 messageData: this.getMessageData(message),
-                err: error
+                err
             });
             // Ack the message. If we failed to parse it, we won't succeed next time.
             message.ack();
@@ -155,12 +155,12 @@ class BatchWorker {
                 batchSize: batchToFlush.length,
                 messageIds: batchToFlush.map(item => item.message.id)
             });
-        } catch (error) {
+        } catch (err) {
             logger.error({
                 event: 'WorkerBatchFlushFailed',
                 batchSize: batchToFlush.length,
                 messageIds: batchToFlush.map(item => item.message.id),
-                err: error
+                err
             });
 
             // Nack all messages in the failed batch
@@ -168,7 +168,7 @@ class BatchWorker {
                 item.message.nack();
             });
 
-            throw error;
+            throw err;
         }
     }
 
@@ -182,12 +182,12 @@ class BatchWorker {
 
             try {
                 await this.flushBatch();
-            } catch (error) {
+            } catch (err) {
                 logger.error({
                     event: 'WorkerScheduledFlushFailed',
                     batchSize: this.batch.length,
                     messageIds: this.batch.map(item => item.message.id),
-                    err: error
+                    err
                 });
             }
 

--- a/src/services/batch-worker/BatchWorker.ts
+++ b/src/services/batch-worker/BatchWorker.ts
@@ -105,7 +105,7 @@ class BatchWorker {
                 event: 'WorkerMessageProcessingFailed',
                 messageId: message.id,
                 messageData: this.getMessageData(message),
-                error
+                err: error
             });
             message.nack();
         }
@@ -121,7 +121,7 @@ class BatchWorker {
                 event: 'WorkerMessageParsingFailed',
                 messageId: message.id,
                 messageData: this.getMessageData(message),
-                error
+                err: error
             });
             // Ack the message. If we failed to parse it, we won't succeed next time.
             message.ack();
@@ -160,7 +160,7 @@ class BatchWorker {
                 event: 'WorkerBatchFlushFailed',
                 batchSize: batchToFlush.length,
                 messageIds: batchToFlush.map(item => item.message.id),
-                error
+                err: error
             });
 
             // Nack all messages in the failed batch
@@ -187,7 +187,7 @@ class BatchWorker {
                     event: 'WorkerScheduledFlushFailed',
                     batchSize: this.batch.length,
                     messageIds: this.batch.map(item => item.message.id),
-                    error
+                    err: error
                 });
             }
 

--- a/src/services/batch-worker/BatchWorker.ts
+++ b/src/services/batch-worker/BatchWorker.ts
@@ -180,13 +180,15 @@ class BatchWorker {
         this.flushTimer = setTimeout(async () => {
             this.flushTimer = null;
 
+            const pendingBatchSize = this.batch.length;
+            const pendingMessageIds = this.batch.map(item => item.message.id);
             try {
                 await this.flushBatch();
             } catch (err) {
                 logger.error({
                     event: 'WorkerScheduledFlushFailed',
-                    batchSize: this.batch.length,
-                    messageIds: this.batch.map(item => item.message.id),
+                    batchSize: pendingBatchSize,
+                    messageIds: pendingMessageIds,
                     err
                 });
             }

--- a/src/services/events/publisher.ts
+++ b/src/services/events/publisher.ts
@@ -41,15 +41,14 @@ class EventPublisher {
             });
 
             return messageId;
-        } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
+        } catch (err) {
             logger.error({
                 event: 'EventPublishFailed',
-                error: errorMessage,
+                err,
                 topic,
                 payload
             });
-            throw error;
+            throw err;
         }
     }
 }

--- a/src/services/salt-store/FileSaltStore.ts
+++ b/src/services/salt-store/FileSaltStore.ts
@@ -55,8 +55,8 @@ export class FileSaltStore implements ISaltStore {
                 // File doesn't exist, create it with empty object
                 await this.writeFile({});
             }
-        } catch (error) {
-            logger.warn({event: 'FileSaltStoreInitializationFailed', error});
+        } catch (err) {
+            logger.warn({event: 'FileSaltStoreInitializationFailed', err});
         }
     }
 
@@ -80,12 +80,12 @@ export class FileSaltStore implements ISaltStore {
                 }
             }
             return records;
-        } catch (error) {
-            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        } catch (err) {
+            if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
                 return {};
             }
             // Handle corrupted file
-            logger.error({event: 'FileSaltStoreReadFailed', error});
+            logger.error({event: 'FileSaltStoreReadFailed', err});
             await this.writeFile({});
             return {};
         }
@@ -247,9 +247,9 @@ export class FileSaltStore implements ISaltStore {
                 }
                 
                 return deletedCount;
-            } catch (error) {
-                logger.error({event: 'FileSaltStoreCleanupFailed', error});
-                throw error;
+            } catch (err) {
+                logger.error({event: 'FileSaltStoreCleanupFailed', err});
+                throw err;
             }
         });
     }

--- a/src/services/salt-store/FirestoreSaltStore.ts
+++ b/src/services/salt-store/FirestoreSaltStore.ts
@@ -101,9 +101,9 @@ export class FirestoreSaltStore implements ISaltStore {
         try {
             // Simple operation to test connectivity - just get the collection reference
             await this.firestore.collection(this.collectionName).limit(1).get();
-        } catch (error) {
+        } catch (err) {
             // Log warning but don't throw - allow graceful degradation
-            logger.warn({event: 'FirestoreSaltStoreHealthCheckFailed', error});
+            logger.warn({event: 'FirestoreSaltStoreHealthCheckFailed', err});
         }
     }
 
@@ -309,17 +309,17 @@ export class FirestoreSaltStore implements ISaltStore {
                     batchSize
                 });
             }
-        } catch (error) {
+        } catch (err) {
             logger.error({
                 event: 'FirestoreSaltStoreCleanupFailed',
-                error,
+                err,
                 deletedCount: totalDeleted,
                 totalToBeDeleted,
                 durationMs: Date.now() - startTime,
                 cutoffDate: cutoffDate.toISOString(),
                 batchSize
             });
-            throw error;
+            throw err;
         }
 
         logger.info({
@@ -356,10 +356,10 @@ export class FirestoreSaltStore implements ISaltStore {
         try {
             // Use existing set method which handles atomic creation
             return await this.set(key, newSalt);
-        } catch (error) {
+        } catch (err) {
             // Handle race condition: another process created the document between our read and create
             // We could do this with a transaction, but it adds unnecessary performance overhead
-            if (error instanceof SaltAlreadyExistsError) {
+            if (err instanceof SaltAlreadyExistsError) {
                 // Another process created it, read and return the existing document
                 const freshSalt = await this.get(key);
                 if (!freshSalt) {
@@ -367,10 +367,10 @@ export class FirestoreSaltStore implements ISaltStore {
                 }
                 return freshSalt;
             }
-            
+
             // Re-throw other errors
-            logger.error({event: 'FirestoreSaltStoreGetOrCreateFailed', error});
-            throw error;
+            logger.error({event: 'FirestoreSaltStoreGetOrCreateFailed', err});
+            throw err;
         }
     }
 }

--- a/src/services/user-signature/UserSignatureService.ts
+++ b/src/services/user-signature/UserSignatureService.ts
@@ -38,8 +38,8 @@ export class UserSignatureService {
             try {
                 const deletedCount = await this.saltStore.cleanup();
                 logger.info({event: 'SaltCleanupCompleted', deletedCount});
-            } catch (error) {
-                logger.error({event: 'SaltCleanupFailed', error});
+            } catch (err) {
+                logger.error({event: 'SaltCleanupFailed', err});
             }
         };
         

--- a/src/utils/error-formatters.ts
+++ b/src/utils/error-formatters.ts
@@ -3,7 +3,7 @@ import {FastifyError, FastifyRequest} from 'fastify';
 export class ErrorDataFormatter {
     static formatValidationError(error: FastifyError, request: FastifyRequest) {
         return {
-            error: {
+            err: {
                 message: error.message,
                 name: error.name,
                 code: error.code,
@@ -21,7 +21,7 @@ export class ErrorDataFormatter {
 
     static formatUnhandledError(error: FastifyError, request: FastifyRequest) {
         return {
-            error: {
+            err: {
                 message: error.message,
                 name: error.name,
                 code: error.code,

--- a/test/integration/error-logging.test.ts
+++ b/test/integration/error-logging.test.ts
@@ -54,7 +54,7 @@ describe('Error Logging', () => {
         // Verify validation error was logged with stack trace and useful request data
         expect(mockWarn).toHaveBeenCalledWith(
             expect.objectContaining({
-                error: expect.objectContaining({
+                err: expect.objectContaining({
                     message: 'querystring must have required property "name"',
                     name: 'FastifyError',
                     code: 'FST_ERR_VALIDATION',
@@ -78,8 +78,8 @@ describe('Error Logging', () => {
 
         // Verify the logged data structure
         const loggedData = mockWarn.mock.calls[0][0];
-        expect(loggedData).toHaveProperty('error.stack');
-        expect(loggedData).toHaveProperty('error.code');
+        expect(loggedData).toHaveProperty('err.stack');
+        expect(loggedData).toHaveProperty('err.code');
         expect(loggedData).toHaveProperty('headers');
         expect(loggedData).toHaveProperty('query');
         expect(loggedData).toHaveProperty('requestBody');
@@ -103,7 +103,7 @@ describe('Error Logging', () => {
         // Verify unhandled error was logged with stack trace and useful request data
         expect(mockError).toHaveBeenCalledWith(
             expect.objectContaining({
-                error: expect.objectContaining({
+                err: expect.objectContaining({
                     message: 'Database connection failed',
                     name: 'DatabaseError',
                     code: 'DATABASE_ERROR',
@@ -127,8 +127,8 @@ describe('Error Logging', () => {
 
         // Verify the logged data structure
         const loggedData = mockError.mock.calls[0][0];
-        expect(loggedData).toHaveProperty('error.stack');
-        expect(loggedData).toHaveProperty('error.code');
+        expect(loggedData).toHaveProperty('err.stack');
+        expect(loggedData).toHaveProperty('err.code');
         expect(loggedData).toHaveProperty('headers');
         expect(loggedData).toHaveProperty('query');
         expect(loggedData).toHaveProperty('requestBody');
@@ -152,8 +152,8 @@ describe('Error Logging', () => {
 
         // Verify the new logging is cleaner and includes stack trace
         const loggedData = mockError.mock.calls[0][0];
-        expect(loggedData).toHaveProperty('error.stack');
-        expect(loggedData).toHaveProperty('error.code');
+        expect(loggedData).toHaveProperty('err.stack');
+        expect(loggedData).toHaveProperty('err.code');
         expect(loggedData).toHaveProperty('headers');
         expect(loggedData).toHaveProperty('query');
         expect(loggedData).toHaveProperty('requestBody');

--- a/test/unit/handlers/page-hit-handlers.test.ts
+++ b/test/unit/handlers/page-hit-handlers.test.ts
@@ -106,11 +106,7 @@ describe('page-hit-handlers', () => {
             expect(publishPageHitRawSpy).toHaveBeenCalledWith(mockRequest, mockPayload);
             expect(mockRequest.log.error).toHaveBeenCalledWith(
                 {
-                    error: {
-                        message: 'Test error message',
-                        stack: testError.stack,
-                        name: 'Error'
-                    },
+                    err: testError,
                     payload: mockPayload,
                     httpRequest: {
                         requestMethod: mockRequest.method,
@@ -140,7 +136,7 @@ describe('page-hit-handlers', () => {
             expect(publishPageHitRawSpy).toHaveBeenCalledWith(mockRequest, mockPayload);
             expect(mockRequest.log.error).toHaveBeenCalledWith(
                 {
-                    error: 'String error',
+                    err: 'String error',
                     payload: mockPayload,
                     httpRequest: {
                         requestMethod: mockRequest.method,
@@ -170,7 +166,7 @@ describe('page-hit-handlers', () => {
             expect(publishPageHitRawSpy).toHaveBeenCalledWith(mockRequest, mockPayload);
             expect(mockRequest.log.error).toHaveBeenCalledWith(
                 {
-                    error: null,
+                    err: null,
                     payload: mockPayload,
                     httpRequest: {
                         requestMethod: mockRequest.method,
@@ -200,7 +196,7 @@ describe('page-hit-handlers', () => {
             expect(publishPageHitRawSpy).toHaveBeenCalledWith(mockRequest, mockPayload);
             expect(mockRequest.log.error).toHaveBeenCalledWith(
                 {
-                    error: undefined,
+                    err: undefined,
                     payload: mockPayload,
                     httpRequest: {
                         requestMethod: mockRequest.method,
@@ -230,7 +226,7 @@ describe('page-hit-handlers', () => {
             expect(publishPageHitRawSpy).toHaveBeenCalledWith(mockRequest, mockPayload);
             expect(mockRequest.log.error).toHaveBeenCalledWith(
                 {
-                    error: complexError,
+                    err: complexError,
                     payload: mockPayload,
                     httpRequest: {
                         requestMethod: mockRequest.method,
@@ -470,11 +466,7 @@ describe('page-hit-handlers', () => {
             options?.onError!(mockReplyInstance, testError as any);
 
             expect(mockReplyInstance.log.error).toHaveBeenCalledWith({
-                error: {
-                    message: 'Proxy connection failed',
-                    stack: testError.stack,
-                    name: 'Error'
-                },
+                err: testError,
                 httpRequest: {
                     requestMethod: mockRequest.method,
                     requestUrl: mockRequest.url,
@@ -518,11 +510,7 @@ describe('page-hit-handlers', () => {
             options?.onError!(mockReplyInstance, wrappedError as any);
 
             expect(mockReplyInstance.log.error).toHaveBeenCalledWith({
-                error: {
-                    message: 'Connection timeout',
-                    stack: innerError.stack,
-                    name: 'Error'
-                },
+                err: innerError,
                 httpRequest: {
                     requestMethod: mockRequest.method,
                     requestUrl: mockRequest.url,

--- a/test/unit/services/batch-worker/batch-worker.test.ts
+++ b/test/unit/services/batch-worker/batch-worker.test.ts
@@ -1,9 +1,31 @@
-import {describe, it, expect, beforeEach, vi, afterEach} from 'vitest';
+import {describe, it, expect, beforeEach, vi, afterEach, afterAll} from 'vitest';
 import {Message} from '@google-cloud/pubsub';
 import BatchWorker from '../../../../src/services/batch-worker/BatchWorker';
 import {EventSubscriber} from '../../../../src/services/events/subscriber';
 import {TinybirdClient} from '../../../../src/services/tinybird/client';
-import logger from '../../../../src/utils/logger';
+import {normalizeLogEntry, type InMemoryLogCapture} from '../../../utils/log-capture';
+
+const {LOG_CAPTURE_KEY} = vi.hoisted(() => ({
+    LOG_CAPTURE_KEY: '__batch_worker_log_capture__'
+}));
+
+vi.mock('../../../../src/utils/logger', async () => {
+    const {createInMemoryLogCapture} = await import('../../../utils/log-capture');
+    const capture = createInMemoryLogCapture();
+    (globalThis as Record<string, unknown>)[LOG_CAPTURE_KEY] = capture;
+    return {
+        default: capture.logger
+    };
+});
+
+const getLogCapture = (): InMemoryLogCapture => {
+    const capture = (globalThis as Record<string, unknown>)[LOG_CAPTURE_KEY];
+    if (!capture) {
+        throw new Error('Log capture has not been initialized');
+    }
+
+    return capture as InMemoryLogCapture;
+};
 
 // Mock EventSubscriber
 vi.mock('../../../../src/services/events/subscriber', () => ({
@@ -25,8 +47,12 @@ vi.mock('../../../../src/services/tinybird/client', () => ({
     })
 }));
 
+let messageIdCounter = 0;
+
 const createMockMessage = (data: string) => {
+    messageIdCounter += 1;
     return {
+        id: `mock-message-${messageIdCounter}`,
         data: Buffer.from(data),
         ack: vi.fn(),
         nack: vi.fn()
@@ -45,10 +71,8 @@ describe('BatchWorker', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        // Mock logger methods to avoid noise in tests
-        vi.spyOn(logger, 'info').mockImplementation(() => {});
-        vi.spyOn(logger, 'debug').mockImplementation(() => {});
-        vi.spyOn(logger, 'error').mockImplementation(() => {});
+        getLogCapture().clear();
+        messageIdCounter = 0;
 
         mockTinybirdClient = new TinybirdClient({
             apiUrl: 'https://api.tinybird.co',
@@ -67,11 +91,18 @@ describe('BatchWorker', () => {
         vi.clearAllMocks();
     });
 
+    afterAll(async () => {
+        await getLogCapture().stop();
+    });
+
     describe('constructor', () => {
         it('should create an instance with the provided topic', () => {
             expect(batchWorker).toBeInstanceOf(BatchWorker);
             expect(EventSubscriber).toHaveBeenCalledWith(testTopic);
-            expect(logger.info).toHaveBeenCalledWith({event: 'BatchWorkerCreating', topic: testTopic});
+
+            const log = getLogCapture().findByEvent('BatchWorkerCreating');
+            expect(log).toBeDefined();
+            expect(normalizeLogEntry(log!)).toMatchObject({event: 'BatchWorkerCreating', topic: testTopic});
         });
     });
 
@@ -79,7 +110,9 @@ describe('BatchWorker', () => {
         it('should start the subscriber with handleMessage callback', async () => {
             await batchWorker.start();
 
-            expect(logger.info).toHaveBeenCalledWith({event: 'BatchWorkerStarting', topic: testTopic});
+            const log = getLogCapture().findByEvent('BatchWorkerStarting');
+            expect(log).toBeDefined();
+            expect(normalizeLogEntry(log!)).toMatchObject({event: 'BatchWorkerStarting', topic: testTopic});
             expect(mockSubscriber.subscribe).toHaveBeenCalledWith(expect.any(Function));
         });
     });
@@ -88,7 +121,9 @@ describe('BatchWorker', () => {
         it('should stop the subscriber', async () => {
             await batchWorker.stop();
 
-            expect(logger.info).toHaveBeenCalledWith({event: 'BatchWorkerStopping', topic: testTopic});
+            const log = getLogCapture().findByEvent('BatchWorkerStopping');
+            expect(log).toBeDefined();
+            expect(normalizeLogEntry(log!)).toMatchObject({event: 'BatchWorkerStopping', topic: testTopic});
             expect(mockSubscriber.close).toHaveBeenCalled();
         });
     });
@@ -145,56 +180,44 @@ describe('BatchWorker', () => {
 
             await (batchWorker as any).handleMessage(mockMessage);
 
-            // Should log debug message with event details for successful processing
-            expect(logger.debug).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    event: 'WorkerProcessedMessage',
-                    messageId: mockMessage.id,
-                    eventId: validPageHitRawData.payload.event_id
-                })
-            );
+            const processedLog = getLogCapture().findByEvent('WorkerProcessedMessage');
+            expect(processedLog).toBeDefined();
+            const normalizedLog = normalizeLogEntry(processedLog!);
+            expect(normalizedLog).toMatchObject({
+                event: 'WorkerProcessedMessage',
+                messageId: mockMessage.id,
+                eventId: validPageHitRawData.payload.event_id,
+                messageData: validPageHitRawData
+            });
 
-            // Should log debug message with full payload
-            expect(logger.debug).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    event: 'WorkerProcessedMessage',
-                    messageId: mockMessage.id,
-                    messageData: validPageHitRawData,
-                    pageHitProcessed: expect.objectContaining({
-                        timestamp: validPageHitRawData.timestamp,
-                        action: validPageHitRawData.action,
-                        version: validPageHitRawData.version,
-                        site_uuid: validPageHitRawData.site_uuid,
-                        session_id: expect.any(String),
-                        payload: expect.objectContaining({
-                            // Original payload fields
-                            member_uuid: validPageHitRawData.payload.member_uuid,
-                            member_status: validPageHitRawData.payload.member_status,
-                            post_uuid: validPageHitRawData.payload.post_uuid,
-                            post_type: validPageHitRawData.payload.post_type,
-                            locale: validPageHitRawData.payload.locale,
-                            location: validPageHitRawData.payload.location,
-                            pathname: validPageHitRawData.payload.pathname,
-                            href: validPageHitRawData.payload.href,
-                            // Processed fields
-                            os: expect.any(String),
-                            browser: expect.any(String),
-                            device: expect.any(String),
-                            // UTM fields from raw data
-                            utm_source: validPageHitRawData.payload.utm_source,
-                            utm_medium: validPageHitRawData.payload.utm_medium,
-                            utm_campaign: validPageHitRawData.payload.utm_campaign,
-                            utm_term: validPageHitRawData.payload.utm_term,
-                            utm_content: validPageHitRawData.payload.utm_content,
-                            // parsedReferrer should be undefined since no parsedReferrer in raw data
-                            parsedReferrer: undefined,
-                            meta: {
-                                received_timestamp: validPageHitRawData.payload.meta.received_timestamp
-                            }
-                        })
-                    })
+            expect(normalizedLog.pageHitProcessed).toMatchObject({
+                timestamp: validPageHitRawData.timestamp,
+                action: validPageHitRawData.action,
+                version: validPageHitRawData.version,
+                site_uuid: validPageHitRawData.site_uuid,
+                session_id: expect.any(String),
+                payload: expect.objectContaining({
+                    member_uuid: validPageHitRawData.payload.member_uuid,
+                    member_status: validPageHitRawData.payload.member_status,
+                    post_uuid: validPageHitRawData.payload.post_uuid,
+                    post_type: validPageHitRawData.payload.post_type,
+                    locale: validPageHitRawData.payload.locale,
+                    location: validPageHitRawData.payload.location,
+                    pathname: validPageHitRawData.payload.pathname,
+                    href: validPageHitRawData.payload.href,
+                    os: expect.any(String),
+                    browser: expect.any(String),
+                    device: expect.any(String),
+                    utm_source: validPageHitRawData.payload.utm_source,
+                    utm_medium: validPageHitRawData.payload.utm_medium,
+                    utm_campaign: validPageHitRawData.payload.utm_campaign,
+                    utm_term: validPageHitRawData.payload.utm_term,
+                    utm_content: validPageHitRawData.payload.utm_content,
+                    meta: {
+                        received_timestamp: validPageHitRawData.payload.meta.received_timestamp
+                    }
                 })
-            );
+            });
 
             // Message should not be acked yet
             expect(mockMessage.ack).not.toHaveBeenCalled();
@@ -224,12 +247,16 @@ describe('BatchWorker', () => {
 
             await (batchWorker as any).handleMessage(mockMessage);
 
-            expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({
+            const log = getLogCapture().findByEvent('WorkerMessageParsingFailed');
+            expect(log).toBeDefined();
+            expect(normalizeLogEntry(log!)).toMatchObject({
                 event: 'WorkerMessageParsingFailed',
                 messageId: mockMessage.id,
-                messageData: invalidJson,
-                error: expect.any(Object)
-            }));
+                messageData: invalidJson
+            });
+
+            expect(log).toHaveProperty('err.message');
+            expect(log).toHaveProperty('err.stack');
 
             expectMessageAcked(mockMessage);
         });
@@ -264,12 +291,16 @@ describe('BatchWorker', () => {
 
             await (batchWorker as any).handleMessage(mockMessage);
 
-            expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({
+            const log = getLogCapture().findByEvent('WorkerMessageParsingFailed');
+            expect(log).toBeDefined();
+            expect(normalizeLogEntry(log!)).toMatchObject({
                 event: 'WorkerMessageParsingFailed',
                 messageId: mockMessage.id,
-                messageData: invalidPageHitRawWithEmptyUserAgent,
-                error: expect.any(Object)
-            }));
+                messageData: invalidPageHitRawWithEmptyUserAgent
+            });
+
+            expect(log).toHaveProperty('err.message');
+            expect(log).toHaveProperty('err.stack');
 
             expectMessageAcked(mockMessage);
         });
@@ -381,19 +412,18 @@ describe('BatchWorker', () => {
             expect(mockMessage.nack).not.toHaveBeenCalled();
             expect(mockTinybirdClient.postEventBatch).not.toHaveBeenCalled();
 
-            // Should log bot filtering
-            expect(logger.info).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    event: 'BotEventFiltered',
-                    messageId: mockMessage.id,
-                    messageData: botData,
-                    pageHitProcessed: expect.objectContaining({
-                        payload: expect.objectContaining({
-                            device: 'bot'
-                        })
+            const log = getLogCapture().findByEvent('BotEventFiltered');
+            expect(log).toBeDefined();
+            expect(normalizeLogEntry(log!)).toMatchObject({
+                event: 'BotEventFiltered',
+                messageId: mockMessage.id,
+                messageData: botData,
+                pageHitProcessed: expect.objectContaining({
+                    payload: expect.objectContaining({
+                        device: 'bot'
                     })
                 })
-            );
+            });
         });
 
         it('should filter Googlebot with Android user agent and acknowledge', async () => {

--- a/test/unit/services/user-signature/UserSignatureService.test.ts
+++ b/test/unit/services/user-signature/UserSignatureService.test.ts
@@ -309,7 +309,7 @@ describe('UserSignatureService', () => {
                 await timeoutCallback();
                 
                 expect(cleanupSpy).toHaveBeenCalledOnce();
-                expect(loggerErrorSpy).toHaveBeenCalledWith({event: 'SaltCleanupFailed', error});
+                expect(loggerErrorSpy).toHaveBeenCalledWith({event: 'SaltCleanupFailed', err: error});
                 
                 service.stopCleanupScheduler();
             });

--- a/test/unit/utils/error-formatters.test.ts
+++ b/test/unit/utils/error-formatters.test.ts
@@ -33,7 +33,7 @@ describe('Error Formatters', () => {
                 const result = ErrorDataFormatter.formatValidationError(validationError, request);
 
                 expect(result).toEqual({
-                    error: {
+                    err: {
                         message: 'error message',
                         name: 'FastifyError',
                         code: 'CODE',
@@ -91,7 +91,7 @@ describe('Error Formatters', () => {
                 const result = ErrorDataFormatter.formatUnhandledError(unhandledError, request);
 
                 expect(result).toEqual({
-                    error: {
+                    err: {
                         message: 'Database connection failed',
                         name: 'DatabaseError',
                         code: 'DATABASE_ERROR',

--- a/test/utils/log-capture.ts
+++ b/test/utils/log-capture.ts
@@ -1,0 +1,78 @@
+import pino, {type Logger, type LoggerOptions} from 'pino';
+import {Writable} from 'node:stream';
+
+export type JsonLog = Record<string, unknown>;
+
+export type InMemoryLogCapture = {
+    logger: Logger;
+    drain: () => Promise<void>;
+    getLogs: () => JsonLog[];
+    findByEvent: (event: string) => JsonLog | undefined;
+    clear: () => void;
+    stop: () => Promise<void>;
+};
+
+export function createInMemoryLogCapture(options: LoggerOptions = {}): InMemoryLogCapture {
+    let lines: string[] = [];
+    let buffer = '';
+
+    const stream = new Writable({
+        write(chunk, _encoding, callback) {
+            buffer += chunk.toString();
+            const split = buffer.split('\n');
+            buffer = split.pop() ?? '';
+            lines.push(...split.filter(Boolean));
+            callback();
+        }
+    });
+
+    const logger = pino({level: 'trace', ...options}, stream);
+
+    const parseLines = (): JsonLog[] => {
+        if (buffer.trim().length > 0) {
+            throw new Error(`Incomplete non-empty log buffer found: ${buffer}`);
+        }
+
+        return lines.map((line) => {
+            try {
+                return JSON.parse(line) as JsonLog;
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                throw new Error(`Non-JSON log line emitted: ${line}\nParse error: ${message}`);
+            }
+        });
+    };
+
+    return {
+        logger,
+        async drain() {
+            await new Promise<void>((resolve) => {
+                setImmediate(resolve);
+            });
+        },
+        getLogs: parseLines,
+        findByEvent(event: string) {
+            return parseLines().find(log => log.event === event);
+        },
+        clear() {
+            lines = [];
+            buffer = '';
+        },
+        stop() {
+            return new Promise<void>((resolve) => {
+                stream.end(() => {
+                    resolve();
+                });
+            });
+        }
+    };
+}
+
+export function normalizeLogEntry(log: JsonLog): JsonLog {
+    const copy = {...log};
+    delete copy.level;
+    delete copy.time;
+    delete copy.pid;
+    delete copy.hostname;
+    return copy;
+}


### PR DESCRIPTION
## Summary

- Updated batch worker error logging to use Pino's `err` field so error message and stack are serialized in structured logs
- Added a reusable in-memory log capture utility for tests at `test/utils/log-capture.ts`
- Migrated batch worker unit tests to assert emitted log output instead of logger spy calls, including error serialization checks