### PR TITLE
Fixed CI package publish permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
     name: Lint and Test (Node ${{ matrix.node }})
     needs: prepare
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         node: ${{ fromJSON(needs.prepare.outputs.node-versions) }}


### PR DESCRIPTION
no refs

## Summary

- Grant the CI lint-and-test job read access to repository contents and write access to packages.
- Keep the GHCR permission scoped to the job that pushes the tree-tagged Docker image.

## Why?

This change is required after some org-level defaults changed, which blocked our CI workflow from publishing to ghcr, thereby blocking all PRs.