### PR TITLE
Added new docs and eliminated drift in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,44 +24,84 @@ TrafficAnalytics is a web analytics proxy service for Ghost that processes and e
 ### Linting
 - `yarn lint` - Run linter in Docker
 
+## Run Modes
+
+The same image runs in two roles, selected by `WORKER_MODE` (see `server.ts`):
+- **Ingest app** (`WORKER_MODE` unset — `src/app.ts`): the Fastify HTTP server that receives `POST /api/v1/page_hit`.
+- **Worker app** (`WORKER_MODE=true` — `src/worker-app.ts`): a Pub/Sub consumer that enriches events and forwards them to Tinybird. Exposes only health endpoints (`/`, `/health`).
+
+The ingest app has two request strategies (see `src/handlers/page-hit-handlers.ts`), chosen by whether `PUBSUB_TOPIC_PAGE_HITS_RAW` is set:
+- **Batch mode (default in dev/prod)**: publish the raw event to the Pub/Sub topic and return `202`; enrichment + forwarding happen later in the worker app. This is the `dev:batch` Compose profile (`analytics-service` + `worker`).
+- **Proxy mode (synchronous)**: no topic set — the request is enriched inline and proxied straight to `PROXY_TARGET` (`/v0/events`). This is the `dev:proxy` Compose profile (`analytics-service-proxy`).
+
+See `docs/architecture.md` for a diagram and deeper detail, and `docs/deployment.md` for the CI/deploy pipeline.
+
 ## Architecture
 
-The service follows a modular architecture:
+Key modules under `src/`:
+- **Entrypoints**: `server.ts` (selects app by `WORKER_MODE`), `src/app.ts` (ingest), `src/worker-app.ts` (worker).
+- **Routes / handlers** (`src/routes/v1`, `src/handlers/page-hit-handlers.ts`): defines `POST /api/v1/page_hit`, chooses batch vs proxy strategy.
+- **Plugins** (`src/plugins/`): `hmac-validation` (global `preValidation` HMAC check), `timestamp` (records `serverReceivedAt` on request), `cors`, `logging`, `proxy` (local `/local-proxy` test endpoint), `worker-plugin` (batch worker lifecycle in the worker app).
+- **Events** (`src/services/events/`): `publisher.ts` / `publisherUtils.ts` publish raw page hits to Pub/Sub; `subscriber.ts` consumes from a subscription. Uses `@google-cloud/pubsub`.
+- **Batch worker** (`src/services/batch-worker/`): subscribes, transforms each message, batches, and flushes to Tinybird (`BATCH_SIZE`, `BATCH_FLUSH_INTERVAL_MS`).
+- **Tinybird** (`src/services/tinybird/`): `client.ts` posts single or NDJSON-batch events to `{PROXY_TARGET}/v0/events?name=analytics_events`.
+- **Transformations / schemas** (`src/transformations/page-hit-transformations.ts`, `src/schemas/v1/`): build the raw payload from the request and transform raw → processed (user-agent parsing via `ua-parser-js`, referrer parsing via `@tryghost/referrer-parser`, user signature, bot filtering).
+- **Salt store** (`src/services/salt-store/`): adapter pattern (`memory`, `file`, `firestore`) behind `ISaltStore`, selected by `SALT_STORE_TYPE`.
+- **User signature** (`src/services/user-signature/`): SHA-256 of daily-rotating salt + site UUID + IP + user agent.
+- **Instrumentation** (`src/utils/instrumentation.ts`): OpenTelemetry setup — Jaeger (default) or Google Cloud Trace.
 
-1. **Proxy Service** (`src/services/proxy/`): Handles request validation and processing
-   - Validates required query parameters (`token` and `name`)
-   - Parses user agents and referrer URLs
-   - Forwards enriched data to upstream
+### Salt Store
 
-2. **Salt Store** (`src/services/salt-store/`): Adapter pattern for salt storage
-   - Currently uses in-memory storage
-   - Configurable via `SALT_STORE_TYPE` environment variable
-
-3. **User Signature Service** (`src/services/user-signature/`): Generates privacy-preserving user signatures
-   - Uses daily-rotating salts
-   - Creates SHA-256 hashes from salt + IP + user agent + timestamp
+Adapter pattern behind `ISaltStore`, selected by `SALT_STORE_TYPE` (see `SaltStoreFactory.ts`):
+- Code default is `memory` (in-process). Docker Compose dev/test override it to `firestore`.
+- Adapters: `memory`, `file` (`SALT_STORE_FILE_PATH`, default `./data/salts.json`), `firestore` (requires `GOOGLE_CLOUD_PROJECT` + `FIRESTORE_DATABASE_ID`; used in dev via the emulator and in production).
 
 ## Request Flow
 
-1. Requests come to `/api/v1/page_hit`
-2. Global HMAC validation plugin extracts and validates HMAC signature and timestamp from URL parameters
-3. preValidation hook validates hmac
-4. preHandler hook processes user agent and referrer data
-5. Request is forwarded to `PROXY_TARGET` (default: `http://localhost:3000/local-proxy`)
+**Batch mode (default):**
+1. `POST /api/v1/page_hit` reaches the ingest app (`src/app.ts`).
+2. Global HMAC plugin validates the signature/timestamp in the URL params and strips them (skipped if `HMAC_SECRET` unset).
+3. `preHandler` (`populateAndTransformPageHitRequest`) applies payload defaults and validates body/query/headers.
+4. The handler builds the raw payload and publishes it to `PUBSUB_TOPIC_PAGE_HITS_RAW`, then responds `202`.
+5. The worker app consumes from `PUBSUB_SUBSCRIPTION_PAGE_HITS_RAW`, enriches each event (user agent, referrer, user signature), filters bot traffic, batches, and posts to Tinybird `/v0/events`.
+
+**Proxy mode (synchronous — no Pub/Sub topic set):**
+1–3 as above.
+4. The handler enriches the request inline (user agent, referrer, user signature), filters bot traffic, and proxies it to `PROXY_TARGET` (default `http://localhost:3000/local-proxy`).
 
 ## Environment Variables
 
+### Core / run mode
 - `PORT` - Server port (default: 3000)
 - `LISTEN_HOST` - Server listen host (default: 0.0.0.0)
-- `PROXY_TARGET` - Upstream URL to forward requests
+- `WORKER_MODE` - When `'true'`, `server.ts` runs the worker app (Pub/Sub consumer) instead of the ingest app (default: unset)
+- `PROXY_TARGET` - Upstream URL to forward requests. Used directly in proxy mode, and as the Tinybird base URL by the worker (`/v0/events` is stripped/re-added). Default: `http://localhost:3000/local-proxy`
+- `TINYBIRD_TRACKER_TOKEN` - Bearer token for authenticating with Tinybird
 - `TINYBIRD_WAIT` - Pass `wait=true` parameter to Tinybird, which makes it respond only after data is ingested (default: false)
 - `LOG_LEVEL` - Logging level (default: info)
-- `SALT_STORE_TYPE` - Salt store implementation (default: memory)
+
+### Pub/Sub (batch mode)
+- `PUBSUB_TOPIC_PAGE_HITS_RAW` - Topic the ingest app publishes raw events to. If set, the ingest app runs in batch mode; if unset, it runs in synchronous proxy mode.
+- `PUBSUB_SUBSCRIPTION_PAGE_HITS_RAW` - Subscription the worker app consumes from
+- `PUBSUB_EMULATOR_HOST` - Pub/Sub emulator address for local dev/test (e.g. `pubsub:8085`)
+- `GOOGLE_CLOUD_PROJECT` - GCP project ID used for Pub/Sub and Firestore
+- `BATCH_SIZE` - Worker flush batch size (default: 50)
+- `BATCH_FLUSH_INTERVAL_MS` - Worker flush interval in ms (default: 1000)
+
+### Salt store
+- `SALT_STORE_TYPE` - Salt store implementation: `memory` | `file` | `firestore` (code default: memory; Docker Compose dev/test default: firestore)
+- `SALT_STORE_FILE_PATH` - Path for the `file` salt store (default: `./data/salts.json`)
+- `FIRESTORE_DATABASE_ID` - Firestore database ID (required for the firestore salt store)
+- `FIRESTORE_EMULATOR_HOST` - Firestore emulator address for local dev/test (e.g. `firestore:8080`)
 - `ENABLE_SALT_CLEANUP_SCHEDULER` - Enable automatic daily salt cleanup (default: true, set to 'false' to disable)
 - `FIRESTORE_CLEANUP_BATCH_SIZE` - Number of Firestore documents to delete per cleanup loop (default: 500, max: 500)
+
+### Security & networking
 - `TRUST_PROXY` - Enable trust proxy to resolve client IPs from X-Forwarded-For headers (default: true, set to 'false' to disable)
 - `HMAC_SECRET` - Secret key for HMAC validation (Optional. Disabled if missing.)
 - `HMAC_VALIDATION_LOG_ONLY` - When set to 'true', HMAC validation failures are logged but requests are not rejected (default: false)
+
+### Tracing (OpenTelemetry)
 - `OTEL_TRACE_EXPORTER` - OpenTelemetry trace exporter type: 'jaeger' (default) or 'gcp' for Google Cloud Trace
 - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` - Custom OTLP traces endpoint (default: http://jaeger:4318/v1/traces)
 - `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` - Custom OTLP metrics endpoint (default: http://jaeger:4318/v1/metrics)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ sequenceDiagram
     Note over User,TB: Analytics event successfully tracked
 ```
 
+### Run modes
+
+The "Process Request" and "forward to Tinybird" steps above happen in one of two ways, and this is how the service runs by default in development and production:
+
+- **Batch mode (default)** — The ingest service validates the request, publishes the raw event to a Google Cloud Pub/Sub topic, and immediately returns `202`. A separate **worker** process consumes from the subscription, enriches each event (user-agent parsing, referrer parsing, user signature), filters bot traffic, batches events, and forwards them to Tinybird's `/v0/events` endpoint. This decouples request handling from Tinybird ingestion. Started with `yarn dev` (alias for `yarn dev:batch`).
+- **Proxy mode (synchronous)** — With no Pub/Sub topic configured, the ingest service enriches the request inline and proxies it straight to Tinybird in the same request/response cycle. Started with `yarn dev:proxy`.
+
+Both modes run from the same image; the role is selected by the `WORKER_MODE` environment variable (worker vs. ingest) and the presence of `PUBSUB_TOPIC_PAGE_HITS_RAW` (batch vs. proxy). See [docs/architecture.md](docs/architecture.md) for a diagram and full detail.
+
 ## Features
 
 - User agent parsing for OS, browser, and device detection
@@ -152,6 +161,13 @@ When a PR is merged to `main`, the following happens automatically:
 ### Manual deployment
 
 You can manually trigger a deployment via the GitHub Actions UI by running the "Deploy" workflow with `workflow_dispatch`.
+
+For the full pipeline (version bump, image build/push to GCP Artifact Registry, Docker Hub release, Cloud Run deploy, health checks, Slack notifications, and rollback), see [docs/deployment.md](docs/deployment.md).
+
+## Documentation
+
+- [docs/architecture.md](docs/architecture.md) — run modes (batch vs. proxy), the Pub/Sub pipeline, salt-store adapters, OpenTelemetry, and the worker.
+- [docs/deployment.md](docs/deployment.md) — CI and deployment pipeline, staging/production, `deploy-staging` label, and rollback.
 
 # Copyright & License 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,83 @@
+# Architecture
+
+Traffic Analytics is a web analytics proxy for Ghost. It receives page-hit events from the `ghost-stats.js` browser script, enriches them (user-agent parsing, referrer parsing, and a privacy-preserving user signature), filters bot traffic, and forwards the result to [Tinybird](https://www.tinybird.co/)'s `/v0/events` endpoint for storage in ClickHouse.
+
+## Run modes
+
+The same Docker image runs in two roles, selected by the `WORKER_MODE` environment variable in [`server.ts`](../server.ts):
+
+- **Ingest app** (`WORKER_MODE` unset — [`src/app.ts`](../src/app.ts)) — the Fastify HTTP server that receives `POST /api/v1/page_hit`.
+- **Worker app** (`WORKER_MODE=true` — [`src/worker-app.ts`](../src/worker-app.ts)) — a Pub/Sub consumer that enriches events and forwards them to Tinybird. It exposes only health endpoints (`/` and `/health`) for Cloud Run.
+
+The ingest app has two request-handling strategies (see [`src/handlers/page-hit-handlers.ts`](../src/handlers/page-hit-handlers.ts)), chosen by whether `PUBSUB_TOPIC_PAGE_HITS_RAW` is set:
+
+- **Batch mode (default in dev and production)** — publish the raw event to the Pub/Sub topic and return `202` immediately. Enrichment and forwarding to Tinybird happen asynchronously in the worker app. This is the `dev:batch` Compose profile: `analytics-service` (ingest) + `worker`.
+- **Proxy mode (synchronous)** — no topic set. The request is enriched inline and proxied straight to `PROXY_TARGET` (`/v0/events`) within the same request/response cycle. This is the `dev:proxy` Compose profile: `analytics-service-proxy`.
+
+## Batch pipeline
+
+```mermaid
+flowchart LR
+    Browser["Browser<br/>ghost-stats.js"]
+
+    subgraph Ingest["Ingest app (src/app.ts)"]
+        HMAC["HMAC validation<br/>(preValidation)"]
+        Pre["Populate + validate<br/>(preHandler)"]
+        Pub["Publish raw event"]
+    end
+
+    Topic(["Pub/Sub topic<br/>PUBSUB_TOPIC_PAGE_HITS_RAW"])
+    Sub(["Pub/Sub subscription<br/>PUBSUB_SUBSCRIPTION_PAGE_HITS_RAW"])
+
+    subgraph Worker["Worker app (src/worker-app.ts)"]
+        Enrich["Enrich:<br/>user agent + referrer<br/>+ user signature"]
+        Bots["Filter bot traffic"]
+        Batch["Batch<br/>(BATCH_SIZE / flush interval)"]
+    end
+
+    TB["Tinybird<br/>POST /v0/events"]
+
+    Browser -->|"POST /api/v1/page_hit"| HMAC
+    HMAC --> Pre --> Pub
+    Pub -->|"202 Accepted"| Browser
+    Pub --> Topic --> Sub --> Enrich
+    Enrich --> Bots --> Batch --> TB
+```
+
+Notes:
+- **HMAC validation** ([`src/plugins/hmac-validation.ts`](../src/plugins/hmac-validation.ts)) is a global `preValidation` hook. It validates the signature and timestamp carried in the URL query parameters and strips them before downstream processing. It is skipped entirely if `HMAC_SECRET` is unset, and it can be run in log-only mode with `HMAC_VALIDATION_LOG_ONLY=true`.
+- **Enrichment** ([`transformPageHitRawToProcessed`](../src/schemas/v1/page-hit-processed.ts)) parses the user agent with `ua-parser-js`, parses the referrer with `@tryghost/referrer-parser`, and computes the `session_id` user signature.
+- **Bot filtering** drops events whose parsed device is `bot` before they reach Tinybird (in both the worker and the synchronous proxy path).
+- **Batching** ([`src/services/batch-worker/BatchWorker.ts`](../src/services/batch-worker/BatchWorker.ts)) accumulates processed events and flushes them to Tinybird as newline-delimited JSON when the batch reaches `BATCH_SIZE` (default 50) or the flush timer fires (`BATCH_FLUSH_INTERVAL_MS`, default 1000ms). Messages are `ack`ed on a successful flush and `nack`ed on failure.
+
+### Synchronous proxy mode
+
+When `PUBSUB_TOPIC_PAGE_HITS_RAW` is not set, the ingest app enriches the request inline and proxies it directly to `PROXY_TARGET` using `@fastify/reply-from`, returning Tinybird's response to the caller. There is no Pub/Sub topic and no separate worker in this mode.
+
+## Pub/Sub
+
+- The publisher ([`src/services/events/publisher.ts`](../src/services/events/publisher.ts)) and subscriber ([`src/services/events/subscriber.ts`](../src/services/events/subscriber.ts)) both use `@google-cloud/pubsub` and read `GOOGLE_CLOUD_PROJECT` for the project ID.
+- In local development and tests, a Pub/Sub emulator is used via `PUBSUB_EMULATOR_HOST`. The Compose stack creates the topic `traffic-analytics-page-hits-raw` and subscription `traffic-analytics-page-hits-raw-sub`.
+
+## Salt store
+
+User signatures depend on a daily-rotating salt, stored via an adapter pattern behind `ISaltStore` and selected by `SALT_STORE_TYPE` (see [`SaltStoreFactory.ts`](../src/services/salt-store/SaltStoreFactory.ts)):
+
+- `memory` — in-process, lost on restart. This is the **code default**.
+- `file` — JSON file at `SALT_STORE_FILE_PATH` (default `./data/salts.json`).
+- `firestore` — Google Cloud Firestore; requires `GOOGLE_CLOUD_PROJECT` and `FIRESTORE_DATABASE_ID`. This is what Docker Compose dev/test use (via the Firestore emulator at `FIRESTORE_EMULATOR_HOST`) and what production uses.
+
+The user signature ([`UserSignatureService`](../src/services/user-signature/UserSignatureService.ts)) is a SHA-256 hash of `salt : site_uuid : ip : user-agent`, where the salt is keyed by date and site UUID so it rotates daily per site. A cleanup scheduler periodically deletes expired salts (`ENABLE_SALT_CLEANUP_SCHEDULER`, `FIRESTORE_CLEANUP_BATCH_SIZE`).
+
+## Observability
+
+OpenTelemetry is initialised in [`src/utils/instrumentation.ts`](../src/utils/instrumentation.ts) before the app loads:
+
+- The trace exporter is Jaeger (OTLP HTTP) by default, or Google Cloud Trace when `OTEL_TRACE_EXPORTER=gcp` or `K_SERVICE` is set (Cloud Run sets `K_SERVICE` automatically).
+- OTLP endpoints default to the `jaeger` service (`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`).
+- The reported service name is `analytics-worker` in worker mode and `analytics-service` otherwise.
+
+## Related docs
+
+- [Deployment](deployment.md) — CI and the deploy pipeline.
+- [AGENTS.md](../AGENTS.md) — module map, commands, and environment variables for contributors and coding agents.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,90 @@
+# Deployment
+
+Traffic Analytics deploys to **Google Cloud Run** in a single region (`europe-west4`, "netherlands"), across **staging** and **production** environments. Each environment runs two Cloud Run services: the ingest service and the worker.
+
+All deployment logic lives in [`.github/workflows/`](../.github/workflows) and a set of composite actions under [`.github/actions/`](../.github/actions).
+
+## Pipeline overview
+
+```mermaid
+flowchart TD
+    Merge["Push to main"] --> Deploy["deploy.yml"]
+    Deploy --> Bump["Bump patch version<br/>commit + tag vX.Y.Z<br/>Slack notify"]
+    Bump --> DH["Trigger docker-hub.yml<br/>(publish to Docker Hub)"]
+    Bump --> Build["deploy-image-to-gcp.yml<br/>build + push to GCP Artifact Registry"]
+    Build --> Stg["deploy-environment.yml<br/>staging (analytics + worker)"]
+    Build --> Prd["deploy-environment.yml<br/>production (analytics + worker)"]
+    Stg --> HCS["run-healthchecks.yml<br/>staging"]
+    Prd --> HCP["run-healthchecks.yml<br/>production"]
+    Stg --> SlackS["Slack deploy summary"]
+    Prd --> SlackP["Slack deploy summary"]
+```
+
+## Deploy on merge to `main` — [`deploy.yml`](../.github/workflows/deploy.yml)
+
+Triggered on every push to `main` (and via manual `workflow_dispatch`). Jobs:
+
+1. **Bump Version** — bumps the patch version with `npm version patch` (e.g. `1.2.3 → 1.2.4`), commits it as `vX.Y.Z [skip ci]`, pushes to `main`, and creates + pushes the `vX.Y.Z` git tag. Sends a Slack "new version released" notification. (Uses a `GH_PAT` so the push can re-trigger downstream workflows.)
+2. **Trigger Docker Hub Deploy** — dispatches [`docker-hub.yml`](../.github/workflows/docker-hub.yml) at the new `vX.Y.Z` tag.
+3. **Build** — calls [`deploy-image-to-gcp.yml`](../.github/workflows/deploy-image-to-gcp.yml) to build and push the image to GCP Artifact Registry.
+4. **Deploy Staging** and **Deploy Production** — both call [`deploy-environment.yml`](../.github/workflows/deploy-environment.yml) after the build, so the two environments deploy in parallel. Each deploys the `analytics` and `worker` services.
+5. **Healthcheck Staging / Production** — each runs [`run-healthchecks.yml`](../.github/workflows/run-healthchecks.yml), gated on its deploy job reporting `success`.
+
+## Build & push image — [`deploy-image-to-gcp.yml`](../.github/workflows/deploy-image-to-gcp.yml)
+
+A reusable (`workflow_call`) workflow that:
+
+- Looks up a **build cache** image in GHCR keyed by the git tree SHA (`ghcr.io/<repo>:tree-<treeSHA>`, pushed by CI on PRs — see below). On a cache hit it reuses that image; otherwise it builds via the `docker-build` action and runs `lint-and-test`.
+- Authenticates to Google Cloud via Workload Identity and logs in to GCP Artifact Registry (`europe-docker.pkg.dev`).
+- Generates tags (`edge` on main, semver tags derived from the `vX.Y.Z` git tag, and `sha-<commit>`) and pushes them to the `DOCKER_IMAGE` repository.
+- Outputs the `image` (`<DOCKER_IMAGE>:sha-<sha>`) and `version` used by the deploy jobs.
+
+## Deploy to an environment — [`deploy-environment.yml`](../.github/workflows/deploy-environment.yml)
+
+Reusable workflow that takes `environment`, `image`, `region`, `region_name`, and a JSON `services` array. It runs a matrix over the services, deploying each to Cloud Run via the [`deploy-gcp-cloud-run`](../.github/actions/deploy-gcp-cloud-run) composite action. Cloud Run service names follow:
+
+```
+<stg|prd>-<region_name>-traffic-analytics[-worker]
+```
+
+(the `-worker` suffix is added for the `worker` service). A `notify` job then posts a Slack deployment summary.
+
+## Docker Hub release — [`docker-hub.yml`](../.github/workflows/docker-hub.yml)
+
+Runs on `workflow_dispatch` (dispatched by `deploy.yml` at the release tag). It only publishes when the tag at `HEAD` matches the current `package.json` version **and** that version differs from the previous commit's version. When triggered, it builds a **multi-architecture** image, runs lint & test, and pushes to Docker Hub as `ghost/traffic-analytics` with `edge`, semver, and `sha` tags.
+
+## Health checks — [`run-healthchecks.yml`](../.github/workflows/run-healthchecks.yml) and [`healthchecks.yml`](../.github/workflows/healthchecks.yml)
+
+`run-healthchecks.yml` is reusable: given an `environment`, it expands to a matrix of known URLs (subdomain, custom-domain, and subdirectory variants for staging/production) and runs the [`run-healthchecks`](../.github/actions/run-healthchecks) action against each, notifying Slack on failure. It is invoked by the deploy pipeline and, on an hourly schedule (plus manual dispatch), by `healthchecks.yml` for continuous monitoring.
+
+## Deploy a PR branch to staging (the `deploy-staging` label) — [`deploy-staging.yml`](../.github/workflows/deploy-staging.yml)
+
+To test a branch on staging **without merging**, add the **`deploy-staging`** label to its PR. The workflow:
+
+1. Waits for the PR's CI run to finish if one is in progress.
+2. Builds and pushes the image, then deploys the `analytics` and `worker` services to staging.
+3. Runs staging health checks.
+4. In a `finalize` step (always runs): comments on the PR with the result and the tree SHA, then **removes the `deploy-staging` label** so it can be re-applied to deploy again.
+
+## Rollback — [`rollback.yml`](../.github/workflows/rollback.yml)
+
+Manual `workflow_dispatch` with two inputs: `environment` (`staging`, `production`, or `both`) and `tag` (a Docker tag already present in GCP Artifact Registry). It redeploys `<DOCKER_IMAGE>:<tag>` to the chosen environment(s) via `deploy-environment.yml`. Note that rollback deploys only the `analytics` service.
+
+## CI on pull requests — [`ci.yml`](../.github/workflows/ci.yml)
+
+On PRs to `main`, CI builds the Docker image and runs lint & tests across a Node version matrix (`20`, `22`, and the version pinned in the Dockerfile). For the Dockerfile-pinned leg it pushes the built image to GHCR tagged `tree-<treeSHA>`, which the deploy pipeline later reuses as a build cache.
+
+## Housekeeping — [`cleanup-ghcr.yml`](../.github/workflows/cleanup-ghcr.yml)
+
+A nightly (06:00 UTC) scheduled job (plus manual dispatch) that prunes old GHCR container image versions, keeping the most recent 15.
+
+> [`test.yml`](../.github/workflows/test.yml) is a manual-dispatch placeholder and is not part of the deploy pipeline.
+
+## Local release helper — `yarn ship`
+
+[`scripts/ship.js`](../scripts/ship.js) is an **optional** local helper (not part of CI). Run from an up-to-date `main`, it prompts for a bump type, creates a `release/vX.Y.Z` branch with the version bump committed, and pushes it so you can open a PR. The automated version bump described above still happens in `deploy.yml` when that PR merges.
+
+## Related docs
+
+- [Architecture](architecture.md) — run modes, the Pub/Sub pipeline, and the worker.
+- [README](../README.md#deployment) — the contributor-facing deployment summary.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,7 +24,7 @@ flowchart TD
 
 Triggered on every push to `main` (and via manual `workflow_dispatch`). Jobs:
 
-1. **Bump Version** — bumps the patch version with `npm version patch` (e.g. `1.2.3 → 1.2.4`), commits it as `vX.Y.Z [skip ci]`, pushes to `main`, and creates + pushes the `vX.Y.Z` git tag. Sends a Slack "new version released" notification. (Uses a `GH_PAT` so the push can re-trigger downstream workflows.)
+1. **Bump Version** — bumps the patch version with `npm version patch` (e.g. `1.2.3 → 1.2.4`), commits it as `vX.Y.Z [skip ci]`, pushes to `main`, and creates + pushes the `vX.Y.Z` git tag. Sends a Slack "new version released" notification. (The commit carries `[skip ci]`, so it does not re-trigger CI/deploy; a `GH_PAT` authorizes the push and tag to the protected branch, and the Docker Hub build is dispatched explicitly by the next job.)
 2. **Trigger Docker Hub Deploy** — dispatches [`docker-hub.yml`](../.github/workflows/docker-hub.yml) at the new `vX.Y.Z` tag.
 3. **Build** — calls [`deploy-image-to-gcp.yml`](../.github/workflows/deploy-image-to-gcp.yml) to build and push the image to GCP Artifact Registry.
 4. **Deploy Staging** and **Deploy Production** — both call [`deploy-environment.yml`](../.github/workflows/deploy-environment.yml) after the build, so the two environments deploy in parallel. Each deploys the `analytics` and `worker` services.
@@ -43,7 +43,7 @@ A reusable (`workflow_call`) workflow that:
 
 Reusable workflow that takes `environment`, `image`, `region`, `region_name`, and a JSON `services` array. It runs a matrix over the services, deploying each to Cloud Run via the [`deploy-gcp-cloud-run`](../.github/actions/deploy-gcp-cloud-run) composite action. Cloud Run service names follow:
 
-```
+```text
 <stg|prd>-<region_name>-traffic-analytics[-worker]
 ```
 


### PR DESCRIPTION
## Summary

First PR of the repo-audit run: documentation. The prior audit found the docs mostly good except **AGENTS.md was materially stale** — it described a synchronous \`PROXY_TARGET\` flow, but the service runs in **batch mode by default** (publish to Pub/Sub → separate worker enriches → forwards to Tinybird).

## Changes
- **AGENTS.md** — correct the request flow (batch + proxy modes), fix the salt-store default, replace the stale module map (removed a nonexistent \`src/services/proxy/\` reference), and complete/group the environment-variable reference (adds \`WORKER_MODE\`, \`PUBSUB_*\`, \`BATCH_*\`, Firestore vars, etc).
- **README.md** — add a "Run modes" section (batch vs proxy) and links to the new docs.
- **docs/architecture.md** *(new)* — Mermaid diagram of the batch pipeline, Pub/Sub, salt-store adapters, and OpenTelemetry.
- **docs/deployment.md** *(new)* — the Cloud Run deploy pipeline, \`deploy-staging\` label flow, and rollback.

Docs-only; no source, config, or workflow changes. Every technical claim was verified against source and the workflow files.

## Context
This is step 1 of a full repo-audit (docs → CI trust → settings/rulesets → pnpm → oxlint). Later PRs that change tooling (pnpm, oxlint) will sweep these docs to keep commands current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)