### PR TITLE
Remove Chromium from production healthchecks

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,10 +16,6 @@ export default defineConfig({
 
     projects: [
         {
-            name: 'chromium',
-            use: {...devices['Desktop Chrome']}
-        },
-        {
             name: 'firefox',
             use: {...devices['Desktop Firefox']}
         },


### PR DESCRIPTION
## What?

- remove Chromium from the Playwright healthcheck projects
- continue running the healthchecks in Firefox and WebKit

## Why?

The production healthchecks are currently failing in chromium only. Fastly is returning `406: Not Acceptable`. I've manually tested in headed Chrome and it's working fine so it seems like a false positive. Disabling chrome healthchecks while we investigate to reduce the noise of failed healthchecks.