### PR TITLE
🎨 Improve logging config performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ Adapter pattern behind `ISaltStore`, selected by `SALT_STORE_TYPE` (see `SaltSto
 - `TINYBIRD_TRACKER_TOKEN` - Bearer token for authenticating with Tinybird
 - `TINYBIRD_WAIT` - Pass `wait=true` parameter to Tinybird, which makes it respond only after data is ingested (default: false)
 - `LOG_LEVEL` - Logging level (default: info)
+- `LOG_FORMAT` - Production log shape: `gcp` (Cloud Logging structured fields) or `json` (plain pino). Defaults to `gcp` when `K_SERVICE`, `GAE_SERVICE` or `GOOGLE_CLOUD_PROJECT` is set, otherwise `json`. Ignored when `NODE_ENV=development`, which always uses pretty logs.
 
 ### Pub/Sub (batch mode)
 - `PUBSUB_TOPIC_PAGE_HITS_RAW` - Topic the ingest app publishes raw events to. If set, the ingest app runs in batch mode; if unset, it runs in synchronous proxy mode.

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@tryghost/validator": "3.2.6",
     "fastify": "5.11.3",
     "fastify-plugin": "6.0.0",
+    "google-auth-library": "10.9.1",
     "pino": "10.3.1",
     "ua-parser-js": "1.0.41"
   }

--- a/src/utils/gcp-logging-shim.ts
+++ b/src/utils/gcp-logging-shim.ts
@@ -1,0 +1,20 @@
+import {GoogleAuth} from 'google-auth-library';
+
+// Replaces the `@google-cloud/logging` package index in the bundle (see `resolve.alias`
+// in vite.config.ts). `@google-cloud/pino-logging-gcp-config` imports the index for the
+// two symbols below, which drags in google-gax, grpc-js and protobufjs — ~470 modules
+// and 7.5MB — to look up a project ID. Its deep import of `.../utils/instrumentation`
+// is left alone and still resolves to the real package.
+
+// Only `.auth` is read, and only to call `getProjectId()`.
+export class Logging {
+    auth = new GoogleAuth({
+        scopes: ['https://www.googleapis.com/auth/logging.write']
+    });
+}
+
+// Unreachable while we pass an explicit `serviceContext`, which is what selects the
+// branch that would call this. Throwing keeps a silent regression from going unnoticed.
+export function detectServiceContext(): never {
+    throw new Error('detectServiceContext is unavailable in the bundled build - pass serviceContext explicitly');
+}

--- a/src/utils/instrumentation.ts
+++ b/src/utils/instrumentation.ts
@@ -12,7 +12,7 @@ import {SpanExporter} from '@opentelemetry/sdk-trace-base';
 // Determine which trace exporter to use based on environment
 function getTraceExporter(): SpanExporter {
     const traceExporterType = process.env.OTEL_TRACE_EXPORTER || 'jaeger';
-    
+
     if (traceExporterType === 'gcp' || process.env.K_SERVICE) {
         // Use Google Cloud Trace for GCP environments
         // K_SERVICE is automatically set by Cloud Run
@@ -27,19 +27,15 @@ function getTraceExporter(): SpanExporter {
 }
 
 // Use K_SERVICE for GCP, or WORKER_MODE for local development
-// TODO: `||` binds tighter than `?:`, so this reads as
-// `(K_SERVICE || WORKER_MODE) ? ... : ...`. K_SERVICE is always set on Cloud Run,
-// so both the ingest and worker services report as 'analytics-worker' in
-// production. Likely intended: `K_SERVICE || (WORKER_MODE ? ... : ...)`.
-// Fixing it renames a service in Cloud Trace, so check dashboards/alerts first.
-const serviceName = process.env.K_SERVICE || process.env.WORKER_MODE ? 'analytics-worker' : 'analytics-service';
+const isWorkerMode = process.env.WORKER_MODE === 'true';
+const serviceName = process.env.K_SERVICE || (isWorkerMode ? 'analytics-worker' : 'analytics-service');
 const serviceVersion = process.env.K_REVISION || 'unknown';
 
 const sdk = new NodeSDK({
     resource: resourceFromAttributes({
         [ATTR_SERVICE_NAME]: serviceName,
         [ATTR_SERVICE_VERSION]: serviceVersion
-    }), 
+    }),
     traceExporter: getTraceExporter(),
     // Only instrumentations that survive the bundled production build: the
     // bundle inlines node_modules, so anything relying on a require hook to

--- a/src/utils/logger-config.ts
+++ b/src/utils/logger-config.ts
@@ -3,6 +3,35 @@ import type {PrettyOptions} from 'pino-pretty';
 import type {FastifyRequest, FastifyReply} from 'fastify';
 import {createGcpLoggingPinoConfig} from '@google-cloud/pino-logging-gcp-config';
 
+const LOG_FORMATS = ['gcp', 'json'] as const;
+
+type LogFormat = typeof LOG_FORMATS[number];
+
+/**
+ * Pick the log format, preferring an explicit LOG_FORMAT over detection.
+ *
+ * `gcp` shapes every record for Cloud Logging; `json` is plain pino output for anywhere
+ * else. Detection keeps existing deployments on `gcp` without new config: K_SERVICE
+ * covers Cloud Run and Cloud Functions, GAE_SERVICE covers App Engine, and GKE and
+ * Compute Engine set neither, so it falls back to GOOGLE_CLOUD_PROJECT, which this
+ * service already requires for Firestore and Pub/Sub.
+ */
+function getLogFormat(): LogFormat {
+    const configured = process.env.LOG_FORMAT;
+
+    if (configured) {
+        if (!LOG_FORMATS.includes(configured as LogFormat)) {
+            throw new Error(`Invalid LOG_FORMAT '${configured}', expected one of: ${LOG_FORMATS.join(', ')}`);
+        }
+
+        return configured as LogFormat;
+    }
+
+    const onGoogleCloud = process.env.K_SERVICE || process.env.GAE_SERVICE || process.env.GOOGLE_CLOUD_PROJECT;
+
+    return onGoogleCloud ? 'gcp' : 'json';
+}
+
 function getServiceContext(): {service: string; version?: string} {
     const isWorkerMode = process.env.WORKER_MODE === 'true';
     const service = process.env.K_SERVICE || (isWorkerMode ? 'analytics-worker' : 'analytics-service');
@@ -50,14 +79,21 @@ export function getLoggerConfig(): LoggerOptions {
         };
     }
 
+    const level = process.env.LOG_LEVEL || 'info';
+
+    // Plain JSON for non-GCP hosts. The GCP config rewrites records into Cloud Logging's
+    // shape and looks up a project ID via the metadata server, neither of which means
+    // anything off GCP.
+    if (getLogFormat() === 'json') {
+        return {level};
+    }
+
     // Production / staging configuration - GCP optimized JSON logs
     return createGcpLoggingPinoConfig(
         {
             serviceContext: getServiceContext(),
             inihibitDiagnosticMessage: Boolean(process.env.VITEST)
         },
-        {
-            level: process.env.LOG_LEVEL || 'info'
-        }
+        {level}
     );
 }

--- a/test/unit/utils/gcp-logging-shim.test.ts
+++ b/test/unit/utils/gcp-logging-shim.test.ts
@@ -1,0 +1,46 @@
+import {describe, it, expect} from 'vitest';
+import {readFileSync} from 'node:fs';
+import {createRequire} from 'node:module';
+import * as shim from '../../../src/utils/gcp-logging-shim';
+
+// The shim stands in for the `@google-cloud/logging` package index in the bundled
+// build (see `resolve.alias` in vite.config.ts). Nothing else enforces that contract:
+// rollup's CommonJS interop resolves a missing symbol to `undefined` rather than
+// failing the build, and these tests run unbundled, so they never load the shim in
+// the position it actually occupies. Read what the wrapper reaches for instead.
+const require = createRequire(import.meta.url);
+const WRAPPER = require.resolve('@google-cloud/pino-logging-gcp-config');
+
+function symbolsReadFromLoggingIndex(): string[] {
+    const source = readFileSync(WRAPPER, 'utf8');
+
+    // Anchored the same way the alias is: the deep `@google-cloud/logging/build/...`
+    // import still resolves to the real package, so its symbols are not our problem.
+    const binding = source.match(/(?:const|let|var)\s+(\w+)\s*=\s*require\(["']@google-cloud\/logging["']\)/);
+    if (!binding) {
+        throw new Error('No `require("@google-cloud/logging")` found - did the wrapper stop importing the index?');
+    }
+
+    const reads = source.matchAll(new RegExp(`\\b${binding[1]}\\.(\\w+)`, 'g'));
+    return [...new Set([...reads].map(match => match[1]))].sort();
+}
+
+describe('gcp-logging-shim', () => {
+    it('exports every symbol the pino wrapper reads off the logging index', () => {
+        const required = symbolsReadFromLoggingIndex();
+
+        expect(required.length).toBeGreaterThan(0);
+        expect(Object.keys(shim).sort()).toEqual(expect.arrayContaining(required));
+    });
+
+    it('exposes auth for the project ID lookup the wrapper performs', () => {
+        // The wrapper only ever reads `.auth` and calls `getProjectId()` on it.
+        expect(typeof new shim.Logging().auth.getProjectId).toBe('function');
+    });
+
+    it('throws rather than silently mis-detecting a service context', () => {
+        // Unreachable while `getLoggerConfig` passes an explicit `serviceContext`,
+        // which is what selects the branch calling this.
+        expect(() => shim.detectServiceContext()).toThrow(/pass serviceContext explicitly/);
+    });
+});

--- a/test/unit/utils/logger.test.ts
+++ b/test/unit/utils/logger.test.ts
@@ -80,6 +80,7 @@ describe('Logger Config', () => {
         it('should return gcp logger config outside development and test', () => {
             vi.stubEnv('NODE_ENV', 'production');
             vi.stubEnv('LOG_LEVEL', 'info');
+            vi.stubEnv('LOG_FORMAT', 'gcp');
 
             const config = getLoggerConfig();
 
@@ -89,10 +90,76 @@ describe('Logger Config', () => {
         });
     });
 
+    describe('log format selection', () => {
+        beforeEach(() => {
+            vi.stubEnv('NODE_ENV', 'production');
+            vi.stubEnv('LOG_LEVEL', 'info');
+            // Cleared individually so detection is not decided by the ambient
+            // environment, which sets GOOGLE_CLOUD_PROJECT for the emulators.
+            vi.stubEnv('LOG_FORMAT', '');
+            vi.stubEnv('K_SERVICE', '');
+            vi.stubEnv('GAE_SERVICE', '');
+            vi.stubEnv('GOOGLE_CLOUD_PROJECT', '');
+        });
+
+        it('should return plain json config when no google cloud environment is detected', () => {
+            const config = getLoggerConfig();
+
+            expect(config).toEqual({level: 'info'});
+        });
+
+        const detectionCases = [
+            {name: 'K_SERVICE', env: 'K_SERVICE', value: 'analytics-service'},
+            {name: 'GAE_SERVICE', env: 'GAE_SERVICE', value: 'analytics-service'},
+            {name: 'GOOGLE_CLOUD_PROJECT', env: 'GOOGLE_CLOUD_PROJECT', value: 'a-project'}
+        ] as const;
+
+        for (const testCase of detectionCases) {
+            it(`should return gcp config when ${testCase.name} is set`, () => {
+                vi.stubEnv(testCase.env, testCase.value);
+
+                const config = getLoggerConfig();
+
+                expect(config.formatters).toHaveProperty('log');
+            });
+        }
+
+        it('should prefer an explicit LOG_FORMAT over detection', () => {
+            vi.stubEnv('K_SERVICE', 'analytics-service');
+            vi.stubEnv('LOG_FORMAT', 'json');
+
+            expect(getLoggerConfig()).toEqual({level: 'info'});
+        });
+
+        it('should use the gcp config when LOG_FORMAT requests it off google cloud', () => {
+            vi.stubEnv('LOG_FORMAT', 'gcp');
+
+            const config = getLoggerConfig();
+
+            expect(config.formatters).toHaveProperty('log');
+        });
+
+        it('should throw on an unrecognised LOG_FORMAT rather than guessing', () => {
+            vi.stubEnv('LOG_FORMAT', 'gpc');
+
+            expect(() => getLoggerConfig()).toThrow(/Invalid LOG_FORMAT 'gpc'/);
+        });
+
+        it('should not apply LOG_FORMAT in development, which is always pretty', () => {
+            vi.stubEnv('NODE_ENV', 'development');
+            vi.stubEnv('LOG_FORMAT', 'gcp');
+
+            expect(getLoggerConfig().transport).toMatchObject({target: 'pino-pretty'});
+        });
+    });
+
     describe('production logging output', () => {
         beforeEach(() => {
             vi.stubEnv('NODE_ENV', 'production');
             vi.stubEnv('LOG_LEVEL', 'info');
+            // Pinned so these assert the GCP record shape rather than the detection
+            // that happens to select it in this environment.
+            vi.stubEnv('LOG_FORMAT', 'gcp');
         });
 
         it('should emit GCP severity field in production logs', async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,19 @@
+import {resolve} from 'node:path';
 import {defineConfig} from 'vite';
 
 export default defineConfig({
     server: {
         port: 3000
+    },
+    resolve: {
+        alias: [
+            // Anchored so only the package index is swapped for the shim; the deep
+            // `@google-cloud/logging/build/src/...` import still hits the real package.
+            {
+                find: /^@google-cloud\/logging$/,
+                replacement: resolve(import.meta.dirname, 'src/utils/gcp-logging-shim.ts')
+            }
+        ]
     },
     build: {
         target: 'esnext',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2629,7 +2629,7 @@ google-auth-library@10.5.0:
     gtoken "^8.0.0"
     jws "^4.0.0"
 
-google-auth-library@^10.5.0, google-auth-library@^10.6.2:
+google-auth-library@10.9.1, google-auth-library@^10.5.0, google-auth-library@^10.6.2:
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-10.9.1.tgz#af9852a328a6077e8ffbe776681b4ca9420a1714"
   integrity sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-280/optimize-traffic-analytics-docker-buildself-hosting-execution
- pino-logging-gcp-config pulled in the entire @google-cloud/logging dependency just to lookup a project id. the full dependency pulls in google-gax + protobufs which bloats the bundle + start time significantly.
- replace logging index import with a shim that replicates the relevant parts
- add LOG_FORMAT env var to disable GCP-formatted logs in non-gcp environments

adding the shim shrinks the final output bundle by almost 2mb, and improves cold-start time (on local APFS at least) by ~30%)

related to #810, but can be merged independently