### PR TITLE
Moved bot detection into a fastify plugin and always apply at the API level

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ FIRESTORE_DATABASE_ID=
 
 # Pub/Sub Configuration (required for pub/sub functionality)
 PUBSUB_TOPIC_PAGE_HITS_RAW=
+
+# Include x-ghost-bot-detected=true on responses for filtered bot traffic (default: false)
+ENABLE_BOT_DETECTION_HEADER=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ The same image runs in two roles, selected by `WORKER_MODE` (see `server.ts`):
 - **Worker app** (`WORKER_MODE=true` — `src/worker-app.ts`): a Pub/Sub consumer that enriches events and forwards them to Tinybird. Exposes only health endpoints (`/`, `/health`).
 
 The ingest app has two request strategies (see `src/handlers/page-hit-handlers.ts`), chosen by whether `PUBSUB_TOPIC_PAGE_HITS_RAW` is set:
-- **Batch mode (default in dev/prod)**: publish the raw event to the Pub/Sub topic and return `202`; enrichment + forwarding happen later in the worker app. This is the `dev:batch` Compose profile (`analytics-service` + `worker`).
-- **Proxy mode (synchronous)**: no topic set — the request is enriched inline and proxied straight to `PROXY_TARGET` (`/v0/events`). This is the `dev:proxy` Compose profile (`analytics-service-proxy`).
+- **Batch mode (default in dev/prod)**: filter bot traffic, publish non-bot raw events to the Pub/Sub topic, and return `202`; enrichment + forwarding happen later in the worker app. This is the `dev:batch` Compose profile (`analytics-service` + `worker`).
+- **Proxy mode (synchronous)**: no topic set — bot traffic is filtered, then non-bot requests are enriched inline and proxied straight to `PROXY_TARGET` (`/v0/events`). This is the `dev:proxy` Compose profile (`analytics-service-proxy`).
 
 See `docs/architecture.md` for a diagram and deeper detail, and `docs/deployment.md` for the CI/deploy pipeline.
 
@@ -41,7 +41,7 @@ See `docs/architecture.md` for a diagram and deeper detail, and `docs/deployment
 Key modules under `src/`:
 - **Entrypoints**: `server.ts` (selects app by `WORKER_MODE`), `src/app.ts` (ingest), `src/worker-app.ts` (worker).
 - **Routes / handlers** (`src/routes/v1`, `src/handlers/page-hit-handlers.ts`): defines `POST /api/v1/page_hit`, chooses batch vs proxy strategy.
-- **Plugins** (`src/plugins/`): `hmac-validation` (global `preValidation` HMAC check), `timestamp` (records `serverReceivedAt` on request), `cors`, `logging`, `proxy` (local `/local-proxy` test endpoint), `worker-plugin` (batch worker lifecycle in the worker app).
+- **Plugins** (`src/plugins/`): `hmac-validation` (global `preValidation` HMAC check), `bot-detection` (page-hit `preHandler` bot filter), `timestamp` (records `serverReceivedAt` on request), `cors`, `logging`, `proxy` (local `/local-proxy` test endpoint), `worker-plugin` (batch worker lifecycle in the worker app).
 - **Events** (`src/services/events/`): `publisher.ts` / `publisherUtils.ts` publish raw page hits to Pub/Sub; `subscriber.ts` consumes from a subscription. Uses `@google-cloud/pubsub`.
 - **Batch worker** (`src/services/batch-worker/`): subscribes, transforms each message, batches, and flushes to Tinybird (`BATCH_SIZE`, `BATCH_FLUSH_INTERVAL_MS`).
 - **Tinybird** (`src/services/tinybird/`): `client.ts` posts single or NDJSON-batch events to `{PROXY_TARGET}/v0/events?name=analytics_events`.
@@ -61,13 +61,13 @@ Adapter pattern behind `ISaltStore`, selected by `SALT_STORE_TYPE` (see `SaltSto
 **Batch mode (default):**
 1. `POST /api/v1/page_hit` reaches the ingest app (`src/app.ts`).
 2. Global HMAC plugin validates the signature/timestamp in the URL params and strips them (skipped if `HMAC_SECRET` unset).
-3. `preHandler` (`populateAndTransformPageHitRequest`) applies payload defaults and validates body/query/headers.
-4. The handler builds the raw payload and publishes it to `PUBSUB_TOPIC_PAGE_HITS_RAW`, then responds `202`.
-5. The worker app consumes from `PUBSUB_SUBSCRIPTION_PAGE_HITS_RAW`, enriches each event (user agent, referrer, user signature), filters bot traffic, batches, and posts to Tinybird `/v0/events`.
+3. Fastify validates the body/query/headers, then the `bot-detection` `preHandler` returns `202` for bot traffic without publishing it. The route `preHandler` (`populateAndTransformPageHitRequest`) applies payload defaults for non-bot requests.
+4. The handler builds non-bot requests into raw payloads and publishes them to `PUBSUB_TOPIC_PAGE_HITS_RAW`, then responds `202`.
+5. The worker app consumes from `PUBSUB_SUBSCRIPTION_PAGE_HITS_RAW`, enriches each event (user agent, referrer, user signature), defensively filters any bot events that bypassed the API, batches, and posts to Tinybird `/v0/events`.
 
 **Proxy mode (synchronous — no Pub/Sub topic set):**
 1–3 as above.
-4. The handler enriches the request inline (user agent, referrer, user signature), filters bot traffic, and proxies it to `PROXY_TARGET` (default `http://localhost:3000/local-proxy`).
+4. The `bot-detection` plugin returns `202` for bot traffic; the handler enriches non-bot requests inline (user agent, referrer, user signature) and proxies them to `PROXY_TARGET` (default `http://localhost:3000/local-proxy`).
 
 ## Environment Variables
 
@@ -100,6 +100,7 @@ Adapter pattern behind `ISaltStore`, selected by `SALT_STORE_TYPE` (see `SaltSto
 - `TRUST_PROXY` - Enable trust proxy to resolve client IPs from X-Forwarded-For headers (default: true, set to 'false' to disable)
 - `HMAC_SECRET` - Secret key for HMAC validation (Optional. Disabled if missing.)
 - `HMAC_VALIDATION_LOG_ONLY` - When set to 'true', HMAC validation failures are logged but requests are not rejected (default: false)
+- `ENABLE_BOT_DETECTION_HEADER` - When set to 'true', filtered bot responses include `x-ghost-bot-detected: true` (default: false; header omitted)
 
 ### Tracing (OpenTelemetry)
 - `OTEL_TRACE_EXPORTER` - OpenTelemetry trace exporter type: 'jaeger' (default) or 'gcp' for Google Cloud Trace

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ sequenceDiagram
 
 The "Process Request" and "forward to Tinybird" steps above happen in one of two ways, and this is how the service runs by default in development and production:
 
-- **Batch mode (default)** — The ingest service validates the request, publishes the raw event to a Google Cloud Pub/Sub topic, and immediately returns `202`. A separate **worker** process consumes from the subscription, enriches each event (user-agent parsing, referrer parsing, user signature), filters bot traffic, batches events, and forwards them to Tinybird's `/v0/events` endpoint. This decouples request handling from Tinybird ingestion. Started with `yarn dev` (alias for `yarn dev:batch`).
-- **Proxy mode (synchronous)** — With no Pub/Sub topic configured, the ingest service enriches the request inline and proxies it straight to Tinybird in the same request/response cycle. Started with `yarn dev:proxy`.
+- **Batch mode (default)** — The ingest service validates the request, filters bot traffic, publishes non-bot raw events to a Google Cloud Pub/Sub topic, and immediately returns `202`. A separate **worker** process consumes from the subscription, enriches each event (user-agent parsing, referrer parsing, user signature), batches events, and forwards them to Tinybird's `/v0/events` endpoint. This decouples request handling from Tinybird ingestion. Started with `yarn dev` (alias for `yarn dev:batch`).
+- **Proxy mode (synchronous)** — With no Pub/Sub topic configured, the ingest service filters bot traffic, enriches non-bot requests inline, and proxies them straight to Tinybird in the same request/response cycle. Started with `yarn dev:proxy`.
 
 Both modes run from the same image; the role is selected by the `WORKER_MODE` environment variable (worker vs. ingest) and the presence of `PUBSUB_TOPIC_PAGE_HITS_RAW` (batch vs. proxy). See [docs/architecture.md](docs/architecture.md) for a diagram and full detail.
 
@@ -57,7 +57,7 @@ Both modes run from the same image; the role is selected by the `WORKER_MODE` en
 
 ## Configuration
 
-Copy `.env.example` to `.env` and configure as needed. For local development with Ghost, see [Develop locally with Ghost](#develop-locally-with-ghost)
+Copy `.env.example` to `.env` and configure as needed. Set `ENABLE_BOT_DETECTION_HEADER=true` to include `x-ghost-bot-detected: true` on `202` responses for filtered bots; this response header is omitted by default. For local development with Ghost, see [Develop locally with Ghost](#develop-locally-with-ghost)
 
 ## Develop
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,9 @@ flowchart LR
 
     subgraph Ingest["Ingest app (src/app.ts)"]
         HMAC["HMAC validation<br/>(preValidation)"]
-        Pre["Populate + validate<br/>(preHandler)"]
+        Validate["Schema validation"]
+        Bots["Filter bot traffic<br/>(preHandler)"]
+        Pre["Populate request defaults<br/>(route preHandler)"]
         Pub["Publish raw event"]
     end
 
@@ -31,23 +33,25 @@ flowchart LR
 
     subgraph Worker["Worker app (src/worker-app.ts)"]
         Enrich["Enrich:<br/>user agent + referrer<br/>+ user signature"]
-        Bots["Filter bot traffic"]
+        BotGuard["Defensive bot check"]
         Batch["Batch<br/>(BATCH_SIZE / flush interval)"]
     end
 
     TB["Tinybird<br/>POST /v0/events"]
 
     Browser -->|"POST /api/v1/page_hit"| HMAC
-    HMAC --> Pre --> Pub
+    HMAC --> Validate --> Bots
+    Bots -->|"bot: 202 Accepted"| Browser
+    Bots -->|"not bot"| Pre --> Pub
     Pub -->|"202 Accepted"| Browser
     Pub --> Topic --> Sub --> Enrich
-    Enrich --> Bots --> Batch --> TB
+    Enrich --> BotGuard --> Batch --> TB
 ```
 
 Notes:
 - **HMAC validation** ([`src/plugins/hmac-validation.ts`](../src/plugins/hmac-validation.ts)) is a global `preValidation` hook. It validates the signature and timestamp carried in the URL query parameters and strips them before downstream processing. It is skipped entirely if `HMAC_SECRET` is unset, and it can be run in log-only mode with `HMAC_VALIDATION_LOG_ONLY=true`.
 - **Enrichment** ([`transformPageHitRawToProcessed`](../src/schemas/v1/page-hit-processed.ts)) parses the user agent with `ua-parser-js`, parses the referrer with `@tryghost/referrer-parser`, and computes the `session_id` user signature.
-- **Bot filtering** drops events whose parsed device is `bot` before they reach Tinybird (in both the worker and the synchronous proxy path).
+- **Bot filtering** runs in the ingest app's [`bot-detection`](../src/plugins/bot-detection.ts) `preHandler` hook before the request strategy is selected, so bot events return the standard `202` accepted response without being published to Pub/Sub or proxied to Tinybird. Set `ENABLE_BOT_DETECTION_HEADER=true` to include `x-ghost-bot-detected: true` on these responses; the header is omitted by default. The worker retains a defensive check for legacy or directly published messages that bypassed the API.
 - **Batching** ([`src/services/batch-worker/BatchWorker.ts`](../src/services/batch-worker/BatchWorker.ts)) accumulates processed events and flushes them to Tinybird as newline-delimited JSON when the batch reaches `BATCH_SIZE` (default 50) or the flush timer fires (`BATCH_FLUSH_INTERVAL_MS`, default 1000ms). Messages are `ack`ed on a successful flush and `nack`ed on failure.
 
 ### Synchronous proxy mode

--- a/src/handlers/page-hit-handlers.ts
+++ b/src/handlers/page-hit-handlers.ts
@@ -2,6 +2,7 @@ import {FastifyReply, FastifyRequest} from 'fastify';
 import {PageHitRequestBodySchema, PageHitRequestHeadersSchema, PageHitRequestQueryParamsSchema, PageHitRequestType, populateAndTransformPageHitRequest, transformPageHitRawToProcessed, type PageHitRequestBodyType, type PageHitRequestHeadersType, type PageHitRequestQueryParamsType} from '../schemas';
 import {publishPageHitRaw} from '../services/events/publisherUtils';
 import {pageHitRawPayloadFromRequest} from '../transformations/page-hit-transformations';
+import {PAGE_HIT_ACCEPTED_RESPONSE} from '../utils/page-hit-response';
 
 const MAX_BODY_SIZE_BYTES = 20 * 1024; // 20 KB
 
@@ -9,7 +10,7 @@ export const handlePageHitRequestStrategyBatch = async (request: PageHitRequestT
     const payload = pageHitRawPayloadFromRequest(request);
     try {
         await publishPageHitRaw(request, payload);
-        reply.status(202).send({message: 'Page hit event received'});
+        reply.status(202).send(PAGE_HIT_ACCEPTED_RESPONSE);
     } catch (err) {
         request.log.error({
             event: 'PageHitPublishFailed',
@@ -33,16 +34,6 @@ export const handlePageHitRequestStrategyBatch = async (request: PageHitRequestT
 export const handlePageHitRequestStrategyInline = async (request: PageHitRequestType, reply: FastifyReply): Promise<void> => {
     const pageHitRaw = pageHitRawPayloadFromRequest(request);
     const pageHitProcessed = await transformPageHitRawToProcessed(pageHitRaw);
-
-    // Filter bot traffic before proxying
-    if (pageHitProcessed.payload.device === 'bot') {
-        request.log.info({
-            event: 'BotEventFiltered',
-            pageHitProcessed
-        });
-        reply.status(202).send();
-        return;
-    }
 
     request.body = pageHitProcessed;
 

--- a/src/plugins/bot-detection.ts
+++ b/src/plugins/bot-detection.ts
@@ -1,0 +1,33 @@
+import {FastifyInstance} from 'fastify';
+import fp from 'fastify-plugin';
+import {isBot} from '../utils/bot-detection';
+import {PAGE_HIT_ACCEPTED_RESPONSE} from '../utils/page-hit-response';
+
+async function botDetectionPlugin(fastify: FastifyInstance) {
+    fastify.addHook('preHandler', async (request, reply) => {
+        const userAgent = request.headers['user-agent'];
+        if (typeof userAgent !== 'string' || !isBot(userAgent)) {
+            return;
+        }
+
+        request.log.info({
+            event: 'BotEventFiltered',
+            httpRequest: {
+                requestMethod: request.method,
+                requestUrl: request.url,
+                userAgent,
+                remoteIp: request.ip
+            }
+        });
+
+        if (process.env.ENABLE_BOT_DETECTION_HEADER === 'true') {
+            reply.header('x-ghost-bot-detected', 'true');
+        }
+
+        return reply.status(202).send(PAGE_HIT_ACCEPTED_RESPONSE);
+    });
+}
+
+export default fp(botDetectionPlugin, {
+    name: 'bot-detection'
+});

--- a/src/routes/v1/page_hit.ts
+++ b/src/routes/v1/page_hit.ts
@@ -1,7 +1,9 @@
 import {FastifyInstance} from 'fastify';
 import {pageHitRouteOptions} from '../../handlers/page-hit-handlers';
+import botDetectionPlugin from '../../plugins/bot-detection';
 
 async function pageHitRoutes(fastify: FastifyInstance) {
+    fastify.register(botDetectionPlugin);
     fastify.post('/', pageHitRouteOptions);
 }
 

--- a/src/schemas/v1/page-hit-processed.ts
+++ b/src/schemas/v1/page-hit-processed.ts
@@ -4,6 +4,7 @@ import type {ParsedReferrer} from './page-hit-raw';
 import uap from 'ua-parser-js';
 import {ReferrerParser} from '@tryghost/referrer-parser';
 import {userSignatureService} from '../../services/user-signature';
+import {isBot} from '../../utils/bot-detection';
 
 const referrerParser = new ReferrerParser();
 
@@ -102,11 +103,6 @@ export function transformUserAgent(userAgent: string): {os: string, browser: str
             device: 'unknown'
         };
     }
-}
-
-function isBot(userAgentString: string): boolean {
-    const botPattern = /wget|ahrefsbot|curl|bot|crawler|spider|urllib|bitdiscovery|\+https:\/\/|googlebot/i;
-    return botPattern.test(userAgentString);
 }
 
 export function transformReferrer(referrerData: ParsedReferrer | undefined): {

--- a/src/utils/bot-detection.ts
+++ b/src/utils/bot-detection.ts
@@ -1,0 +1,5 @@
+const BOT_PATTERN = /wget|ahrefsbot|curl|bot|crawler|spider|urllib|bitdiscovery|\+https:\/\/|googlebot/i;
+
+export function isBot(userAgent: string): boolean {
+    return BOT_PATTERN.test(userAgent);
+}

--- a/src/utils/page-hit-response.ts
+++ b/src/utils/page-hit-response.ts
@@ -1,0 +1,3 @@
+export const PAGE_HIT_ACCEPTED_RESPONSE = {
+    message: 'Page hit event received'
+} as const;

--- a/test/unit/plugins/bot-detection.test.ts
+++ b/test/unit/plugins/bot-detection.test.ts
@@ -1,0 +1,99 @@
+import {afterEach, beforeEach, describe, expect, it, vi, type Mock} from 'vitest';
+import fastify, {FastifyInstance} from 'fastify';
+import botDetectionPlugin from '../../../src/plugins/bot-detection';
+import {PAGE_HIT_ACCEPTED_RESPONSE} from '../../../src/utils/page-hit-response';
+
+const routeOptions = {
+    schema: {
+        headers: {
+            type: 'object',
+            required: ['x-site-id'],
+            properties: {
+                'x-site-id': {type: 'string'}
+            }
+        }
+    }
+};
+
+describe('bot detection plugin', () => {
+    let app: FastifyInstance;
+    let handler: Mock<() => void>;
+
+    beforeEach(() => {
+        vi.stubEnv('ENABLE_BOT_DETECTION_HEADER', undefined);
+        app = fastify();
+        handler = vi.fn();
+        app.register(botDetectionPlugin);
+        app.post('/page-hit', routeOptions, async (_request, reply) => {
+            handler();
+            return reply.status(202).send(PAGE_HIT_ACCEPTED_RESPONSE);
+        });
+    });
+
+    afterEach(async () => {
+        await app.close();
+        vi.unstubAllEnvs();
+    });
+
+    it('should return 202 without invoking the handler for bot traffic', async () => {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/page-hit',
+            headers: {
+                'user-agent': 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+                'x-site-id': 'test-site'
+            }
+        });
+
+        expect(response.statusCode).toBe(202);
+        expect(response.json()).toEqual(PAGE_HIT_ACCEPTED_RESPONSE);
+        expect(response.headers['x-ghost-bot-detected']).toBeUndefined();
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('should include the bot detection header when enabled', async () => {
+        vi.stubEnv('ENABLE_BOT_DETECTION_HEADER', 'true');
+
+        const response = await app.inject({
+            method: 'POST',
+            url: '/page-hit',
+            headers: {
+                'user-agent': 'Googlebot/2.1',
+                'x-site-id': 'test-site'
+            }
+        });
+
+        expect(response.statusCode).toBe(202);
+        expect(response.json()).toEqual(PAGE_HIT_ACCEPTED_RESPONSE);
+        expect(response.headers['x-ghost-bot-detected']).toBe('true');
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('should allow regular traffic to reach the handler', async () => {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/page-hit',
+            headers: {
+                'user-agent': 'Mozilla/5.0 Test Browser',
+                'x-site-id': 'test-site'
+            }
+        });
+
+        expect(response.statusCode).toBe(202);
+        expect(response.json()).toEqual(PAGE_HIT_ACCEPTED_RESPONSE);
+        expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('should run after schema validation', async () => {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/page-hit',
+            headers: {
+                'user-agent': 'Googlebot/2.1'
+            }
+        });
+
+        expect(response.statusCode).toBe(400);
+        expect(handler).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
In batch mode this moves the bot detection from the worker and to the API. This means the request determines if the event should be dropped before ever sending it to the worker queue.

Along side this there is a new ENABLE_BOT_DETECTION_HEADER environment variable which can be used to turn on a response header to identify requests detected as bots. This should be stripped before sending to the client but is great for debugging.