### PR TITLE
Removed Node 20 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         id: set-matrix
         run: |
           DOCKERFILE_VERSION=${{ steps.extract-node-version.outputs.node-version }}
-          VERSIONS=$(echo "[20, 22, $DOCKERFILE_VERSION]" | jq -c 'unique')
+          VERSIONS=$(echo "[22, $DOCKERFILE_VERSION]" | jq -c 'unique')
           echo "node-versions=$VERSIONS" >> $GITHUB_OUTPUT
 
   lint-and-test:


### PR DESCRIPTION
no refs

## Summary

- remove Node 20 from the CI test matrix
- retain Node 22 and the Dockerfile-selected Node version

## Why?

This repo is only published as a container image, so we control the node version in the public distribution. We only publish a Node 22 container, so we shouldn't need to run tests in Node 20 anymore.