### PR TITLE
Fixed healthcheck Node version

### DIFF
--- a/.github/actions/run-healthchecks/action.yml
+++ b/.github/actions/run-healthchecks/action.yml
@@ -20,10 +20,14 @@ runs:
       run: |
         curl -s --max-time 30 -o /dev/null "${{ inputs.base_url }}" &
 
+    - name: Extract Node version
+      id: extract-node-version
+      uses: ./.github/actions/extract-node-version
+
     - name: Setup Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
-        node-version: '20'
+        node-version: ${{ steps.extract-node-version.outputs.node-version }}
         cache: 'yarn'
 
     - name: Install dependencies


### PR DESCRIPTION
## What changed

- derive the healthcheck runner's Node version from the Dockerfile using the existing extraction action
- remove the healthcheck action's hard-coded Node 20 pin

## Why

`@google-cloud/pubsub@6.0.0` requires Node 22 or newer. The application and normal CI already use Node 22, but scheduled healthchecks separately installed dependencies with Node 20.20.2. As a result, every healthcheck matrix job failed during `yarn install` before Playwright made an HTTP request.

Using the Dockerfile as the shared version source fixes the current failure and prevents these workflows from drifting again.

## Validation

- `yarn install --ignore-scripts --frozen-lockfile` under Node 22.23.1
- YAML parse check
- `git diff --check`
- pre-commit checks: lint and 419 unit tests
