### PR TITLE
Fixed Playwright healthcheck invocation

### DIFF
--- a/.github/actions/run-healthchecks/action.yml
+++ b/.github/actions/run-healthchecks/action.yml
@@ -76,7 +76,7 @@ runs:
           -e PW_TEST_HTML_REPORT_OPEN=never \
           --network host \
           "$IMAGE" \
-          bash -c "yarn playwright test --reporter=list --reporter=html"
+          bash -c "./node_modules/.bin/playwright test --reporter=list --reporter=html"
 
     - name: Upload test results
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
## Summary

- invoke the installed Playwright binary directly inside the Playwright container
- avoid Yarn rejecting the healthcheck because the container uses Node 24 while the service requires Node 22
- keep the application runtime constraint unchanged

## Validation

- YAML parse check
- direct Playwright binary reports version 1.62.1
- lint
- 419 unit tests