### PR TITLE
Prevented package from being accidentally published to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "traffic-analytics",
+  "private": true,
   "version": "1.0.359",
   "repository": "git@github.com:TryGhost/TrafficAnalytics.git",
   "author": "Ghost Foundation",


### PR DESCRIPTION
no ref

This change should have no user impact. It prevents us from accidentally publishing this as an npm package.
