### PR TITLE
Improved local development experience in tandem with local development of Ghost

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,10 @@ Pre-requisites:
 
 If you want to manually test the Analytics Service + Ghost together locally, there are just a few more steps to follow. You'll need this repo and TryGhost/Ghost cloned locally.
 
-1. In Ghost, add `ANALYTICS_PROXY_TARGET=traffic-analytics-analytics-service-1:3000` to your `.env` file. This tells Ghost's `caddy` service to route requests to `/.ghost/analytics/**` to this instance of the analytics service instead of the instance in Ghost's compose project.
-1. In Ghost, run `docker compose --profile analytics up -d`. This starts `tinybird-local`, deploys the Tinybird schema, and stored required tokens in a `shared-config` named volume.
-1. In Ghost, run `docker compose --profile split up`. This runs Caddy, Ghost's backend and Ghost Admin. Ghost will be available at `http://localhost:2368`
-1. In this repo, run `yarn dev:ghost` instead of `yarn dev`. This runs the analytics service within Ghost's docker network, and mounts the `shared-config` volume so it can access the tokens it needs to send events to `tinybird-local`.
+1. In Ghost, run `pnpm dev:analytics:local`. This starts Ghost, `tinybird-local`, and the published analytics image, while routing `/.ghost/analytics/**` requests to the stable network alias provided by this repository. The published analytics container remains running, but the gateway sends page hits to this local checkout instead.
+1. In this repo, run `yarn dev:ghost`. This starts the batch-mode ingest service and worker, joins them to Ghost's Docker network, and mounts its `shared-config` volume so they can reach `tinybird-local` with the generated tracker token.
 
-That's it! Now when you visit Ghost at `http://localhost:2368`, you should see the requests to `/.ghost/analytics/api/v1/page_hit` in the request logs in this repo, and the `worker` service will send the events to the `tinybird-local` service running in the Ghost project.
+Now when you visit Ghost at `http://localhost:2368`, you should see requests to `/.ghost/analytics/api/v1/page_hit` in this repository's logs, and the worker will send those events to the `tinybird-local` service running in the Ghost project.
 
 ## Test
 

--- a/compose.ghost.yml
+++ b/compose.ghost.yml
@@ -1,27 +1,26 @@
 # Override file to allow running Ghost locally against the analytics service in this repo
-# Usage: `docker compose -f compose.ghost.yml -f compose.yml up`
+# Usage: `docker compose -f compose.yml -f compose.ghost.yml -f compose.override.yml up`
 
 services:
   analytics-service:
     volumes:
-      - ghost_shared-config:/mnt/shared-config:ro
+      - ghost-shared-config:/mnt/shared-config:ro
     networks:
-      - ghost_default
+      ghost:
+        aliases:
+          - traffic-analytics-local
   worker:
     volumes:
-      - ghost_shared-config:/mnt/shared-config:ro
+      - ghost-shared-config:/mnt/shared-config:ro
     networks:
-      - ghost_default
-  analytics-service-proxy:
-    volumes:
-      - ghost_shared-config:/mnt/shared-config:ro
-    networks:
-      - ghost_default
+      - ghost
 
 volumes:
-  ghost_shared-config:
+  ghost-shared-config:
     external: true
+    name: ghost-dev_shared-config
 
 networks:
-  ghost_default:
+  ghost:
     external: true
+    name: ghost_dev

--- a/compose.ghost.yml
+++ b/compose.ghost.yml
@@ -1,5 +1,5 @@
 # Override file to allow running Ghost locally against the analytics service in this repo
-# Usage: `docker compose -f compose.yml -f compose.ghost.yml -f compose.override.yml up`
+# Usage: Start Ghost with `pnpm dev:analytics:local`, then run `yarn dev:ghost`
 
 services:
   analytics-service:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "yarn dev:batch",
     "dev:proxy": "docker compose up -d --wait && docker compose up analytics-service-proxy",
     "dev:batch": "docker compose up -d --wait && docker compose up analytics-service worker",
-    "dev:ghost": "docker compose up -d --wait && docker compose -f compose.yml -f compose.ghost.yml -f compose.override.yml up analytics-service worker",
+    "dev:ghost": "docker compose -f compose.yml -f compose.ghost.yml -f compose.override.yml up -d --wait && docker compose -f compose.yml -f compose.ghost.yml -f compose.override.yml up --force-recreate analytics-service worker",
     "start": "node --enable-source-maps dist/server.js",
     "start:worker": "WORKER_MODE=true node --enable-source-maps dist/server.js",
     "pretest": "yarn build",


### PR DESCRIPTION
refs https://linear.app/ghost/issue/NY-1550/make-it-easier-to-do-development-with-both-ghost-and-traffic-analytics

This is a development only change that should have no user impact.

_Note: this PR depends on [this PR](https://github.com/TryGhost/Ghost/pull/30328) in the TryGhost/Ghost repo._

## Summary

- In the past, it's been possible to easily run Ghost w/ Tinybird against a locally running instance of this Traffic Analytics service, so you can develop against Ghost and this service simultaneously. When Ghost's development environment stabilized on the current docker compose setup, this functionality was broken, largely because the default docker network changed in Ghost.
- This updates the implementation in the analytics service to use the right network and volume names, which once again will allow us to run Ghost locally against the local analytics service.

## TL;DR of how this works
1. `compose.ghost.yaml` adds the analytics service to the default docker network created by Ghost's own `pnpm dev` command.
2. In Ghost, running `pnpm dev:analytics:local` runs Tinybird and other supporting services, and also instructs Caddy (via an environment variable) to route requests to the analytics service to _this instance_ of the analytics service, rather than the published image that's part of Traffic Analytics.
3. Ghost's shared-config volume is also mounted into the analytics service / worker so it can communicate with Ghost's `tinybird-local` instance. The shared-config volume contains (amongst other things) credentials for sending data to tinybird-local.