### PR TITLE
Add stable 'CI success' aggregate gate for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,27 @@ jobs:
           IMAGE_NAME_LOWER=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')
           docker tag ${{ steps.docker-build.outputs.production-image-name }} "$IMAGE_NAME_LOWER"
           docker push "$IMAGE_NAME_LOWER"
+
+  # Stable aggregate gate for branch protection. Require this single check in the
+  # ruleset instead of a matrix-leg name like "Lint and Test (Node 22)", which
+  # renames (and silently stops gating) whenever the Node matrix changes. Runs
+  # on every matrix leg via `needs` and fails if any of them did not succeed.
+  ci-success:
+    name: CI success
+    if: always()
+    needs: [prepare, lint-and-test]
+    runs-on: ubuntu-latest
+    steps:
+      # Fail closed: require every needed job to be exactly 'success'. Checking
+      # only for 'failure'/'cancelled' would let a 'skipped' result pass — e.g.
+      # if prepare emitted an empty matrix, lint-and-test would be skipped and
+      # this gate would go green with zero tests run.
+      - name: Fail unless every required job succeeded
+        if: ${{ needs.prepare.result != 'success' || needs.lint-and-test.result != 'success' }}
+        run: |
+          echo "One or more required CI jobs did not succeed:"
+          echo "  prepare:       ${{ needs.prepare.result }}"
+          echo "  lint-and-test: ${{ needs.lint-and-test.result }}"
+          exit 1
+      - name: All required CI jobs passed
+        run: echo "All required CI jobs passed"


### PR DESCRIPTION
Part of the repo audit (Step 4: settings & rulesets). **Stacked on #866** (base `repo-audit/pnpm`) — merge that first; GitHub auto-retargets this to `main`.

## The problem
The `Protect Main` ruleset requires the status check **`Lint and Test (Node 22)`** — a matrix-leg name. If the Node version in the matrix ever changes, that check renames, and branch protection would require a check that no longer runs: it either blocks all PRs forever or silently stops gating. Requiring a per-matrix-leg name is fragile.

## This PR
Adds a single **`CI success`** job to `ci.yml` that `needs: [prepare, lint-and-test]` and fails if any leg didn't succeed. Its name is stable regardless of the matrix, so the ruleset can require *one* check that always reflects "did all of CI pass". No behavior change to the existing jobs.

## Follow-up settings changes (manual, admin — after this merges)
These are GitHub config, not code, and need doing once `CI success` is running on `main`:
1. **Swap the required check** on the `Protect Main` ruleset: `Lint and Test (Node 22)` → `CI success`.
2. **Delete the redundant `Protect default branch` ruleset** (16859469) — its only rule (block deletion) is already covered by `Protect Main`.

(Disabling rebase-merge was considered and dropped: the ruleset already enforces `allowed_merge_methods: ["squash"]` for `main`, so the repo-level toggle is moot.)

https://claude.ai/code/session_019VZskjJgacTYkiystBAHmP
