### PR TITLE
Add automation worker deployment scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ TINYBIRD_TRACKER_TOKEN=p.eyJxxxxxxxx
 # PROXY_TARGET=http://host.docker.internal:7181/v0/events # a locally running instance of tinybird-local
 # PROXY_TARGET=https://api.tinybird.co/v0/events # if using a live Tinybird Cloud workspace
 
+# Select the process role: unset for ingest, true for page-hit worker, automation for automation worker
+WORKER_MODE=
+
 # Google Cloud Project Configuration (required when using firestore salt store)
 GOOGLE_CLOUD_PROJECT=traffic-analytics-dev
 

--- a/.github/actions/deploy-gcp-cloud-run/action.yml
+++ b/.github/actions/deploy-gcp-cloud-run/action.yml
@@ -20,6 +20,9 @@ inputs:
   gcp_workload_identity_provider:
     description: The GCP workload identity provider
     required: true
+  env_vars:
+    description: Environment variables to set on the Cloud Run service
+    required: false
 
 runs:
   using: composite
@@ -37,6 +40,7 @@ runs:
         image: ${{ inputs.image }}
         region: ${{ inputs.region }}
         service: ${{ inputs.service }}
+        env_vars: ${{ inputs.env_vars }}
         skip_default_labels: true
         labels: |-
           commit-sha=${{ github.sha }}

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -46,8 +46,9 @@ jobs:
         with:
           environment: ${{ inputs.environment }}
           region: ${{ inputs.region }}
-          service: ${{ inputs.environment == 'staging' && 'stg' || 'prd' }}-${{ inputs.region_name }}-traffic-analytics${{ matrix.service == 'worker' && '-worker' || '' }}
+          service: ${{ inputs.environment == 'staging' && 'stg' || 'prd' }}-${{ inputs.region_name }}-traffic-analytics${{ matrix.service == 'worker' && '-worker' || matrix.service == 'automation-worker' && '-automation-worker' || '' }}
           image: ${{ inputs.image }}
+          env_vars: ${{ matrix.service == 'worker' && 'WORKER_MODE=true' || matrix.service == 'automation-worker' && 'WORKER_MODE=automation' || 'WORKER_MODE=false' }}
           gcp_project_id: ${{ vars.GCP_PROJECT_ID }}${{ inputs.environment == 'staging' && '-stg' || '' }}
           gcp_workload_identity_provider: ${{ inputs.environment == 'staging' && vars.GCP_WORKFLOW_IDENTITY_PROVIDER_STG || vars.GCP_WORKFLOW_IDENTITY_PROVIDER_PRD }}
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -51,7 +51,7 @@ jobs:
       image: ${{ needs.deploy-image-to-gcp.outputs.image }}
       region: europe-west4
       region_name: netherlands
-      services: '["analytics", "worker"]'
+      services: '["analytics", "worker", "automation-worker"]'
 
   healthchecks:
     name: Healthchecks

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,7 @@ jobs:
       image: ${{ needs.build.outputs.version && format('{0}:{1}', vars.DOCKER_IMAGE, needs.build.outputs.version) || '' }}
       region: europe-west4
       region_name: netherlands
-      services: '["analytics", "worker"]'
+      services: '["analytics", "worker", "automation-worker"]'
 
   healthcheck-staging:
     name: Healthcheck Staging
@@ -121,7 +121,7 @@ jobs:
       image: ${{ needs.build.outputs.version && format('{0}:{1}', vars.DOCKER_IMAGE, needs.build.outputs.version) || '' }}
       region: europe-west4
       region_name: netherlands
-      services: '["analytics", "worker"]'
+      services: '["analytics", "worker", "automation-worker"]'
 
   healthcheck-production:
     name: Healthcheck Production

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,10 @@ TrafficAnalytics is a web analytics proxy service for Ghost that processes and e
 
 ## Run Modes
 
-The same image runs in two roles, selected by `WORKER_MODE` (see `server.ts`):
+The same image runs in three roles, selected by `WORKER_MODE` (see `server.ts`):
 - **Ingest app** (`WORKER_MODE` unset — `src/app.ts`): the Fastify HTTP server that receives `POST /api/v1/page_hit`.
 - **Worker app** (`WORKER_MODE=true` — `src/worker-app.ts`): a Pub/Sub consumer that enriches events and forwards them to Tinybird. Exposes only health endpoints (`/`, `/health`).
+- **Automation worker app** (`WORKER_MODE=automation` — `src/automation-worker-app.ts`): a deployable worker scaffold with health endpoints and heartbeat logging. It does not subscribe to Pub/Sub yet.
 
 The ingest app has two request strategies (see `src/handlers/page-hit-handlers.ts`), chosen by whether `PUBSUB_TOPIC_PAGE_HITS_RAW` is set:
 - **Batch mode (default in dev/prod)**: filter bot traffic, publish non-bot raw events to the Pub/Sub topic, and return `202`; enrichment + forwarding happen later in the worker app. This is the `dev:batch` Compose profile (`analytics-service` + `worker`).
@@ -39,9 +40,9 @@ See `docs/architecture.md` for a diagram and deeper detail, and `docs/deployment
 ## Architecture
 
 Key modules under `src/`:
-- **Entrypoints**: `server.ts` (selects app by `WORKER_MODE`), `src/app.ts` (ingest), `src/worker-app.ts` (worker).
+- **Entrypoints**: `server.ts` (selects app by `WORKER_MODE`), `src/app.ts` (ingest), `src/worker-app.ts` (page-hit worker), `src/automation-worker-app.ts` (automation worker scaffold).
 - **Routes / handlers** (`src/routes/v1`, `src/handlers/page-hit-handlers.ts`): defines `POST /api/v1/page_hit`, chooses batch vs proxy strategy.
-- **Plugins** (`src/plugins/`): `hmac-validation` (global `preValidation` HMAC check), `bot-detection` (page-hit `preHandler` bot filter), `timestamp` (records `serverReceivedAt` on request), `cors`, `logging`, `proxy` (local `/local-proxy` test endpoint), `worker-plugin` (batch worker lifecycle in the worker app).
+- **Plugins** (`src/plugins/`): `hmac-validation` (global `preValidation` HMAC check), `bot-detection` (page-hit `preHandler` bot filter), `timestamp` (records `serverReceivedAt` on request), `cors`, `logging`, `proxy` (local `/local-proxy` test endpoint), `worker-plugin` (batch worker lifecycle in the page-hit worker), `automation-worker-plugin` (automation worker startup and heartbeat lifecycle).
 - **Events** (`src/services/events/`): `publisher.ts` / `publisherUtils.ts` publish raw page hits to Pub/Sub; `subscriber.ts` consumes from a subscription. Uses `@google-cloud/pubsub`.
 - **Batch worker** (`src/services/batch-worker/`): subscribes, transforms each message, batches, and flushes to Tinybird (`BATCH_SIZE`, `BATCH_FLUSH_INTERVAL_MS`).
 - **Tinybird** (`src/services/tinybird/`): `client.ts` posts single or NDJSON-batch events to `{PROXY_TARGET}/v0/events?name=analytics_events`.
@@ -89,7 +90,7 @@ Adapter pattern behind `ISaltStore`, selected by `SALT_STORE_TYPE` (see `SaltSto
 ### Core / run mode
 - `PORT` - Server port (default: 3000)
 - `LISTEN_HOST` - Server listen host (default: 0.0.0.0)
-- `WORKER_MODE` - When `'true'`, `server.ts` runs the worker app (Pub/Sub consumer) instead of the ingest app (default: unset)
+- `WORKER_MODE` - Process role: unset runs the ingest app, `'true'` runs the page-hit Pub/Sub worker, and `'automation'` runs the automation worker scaffold
 - `PROXY_TARGET` - Upstream URL to forward requests. Used directly in proxy mode, and as the Tinybird base URL by the worker (`/v0/events` is stripped/re-added). Default: `http://localhost:3000/local-proxy`
 - `TINYBIRD_TRACKER_TOKEN` - Bearer token for authenticating with Tinybird
 - `TINYBIRD_WAIT` - Pass `wait=true` parameter to Tinybird, which makes it respond only after data is ingested (default: false)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The "Process Request" and "forward to Tinybird" steps above happen in one of two
 - **Batch mode (default)** — The ingest service validates the request, filters bot traffic, publishes non-bot raw events to a Google Cloud Pub/Sub topic, and immediately returns `202`. A separate **worker** process consumes from the subscription, enriches each event (user-agent parsing, referrer parsing, user signature), batches events, and forwards them to Tinybird's `/v0/events` endpoint. This decouples request handling from Tinybird ingestion. Started with `pnpm dev` (alias for `pnpm dev:batch`).
 - **Proxy mode (synchronous)** — With no Pub/Sub topic configured, the ingest service filters bot traffic, enriches non-bot requests inline, and proxies them straight to Tinybird in the same request/response cycle. Started with `pnpm dev:proxy`.
 
-Both modes run from the same image; the role is selected by the `WORKER_MODE` environment variable (worker vs. ingest) and the presence of `PUBSUB_TOPIC_PAGE_HITS_RAW` (batch vs. proxy). See [docs/architecture.md](docs/architecture.md) for a diagram and full detail.
+All roles run from the same image; `WORKER_MODE` selects ingest, page-hit worker, or automation worker, while `PUBSUB_TOPIC_PAGE_HITS_RAW` selects batch vs. proxy handling for ingest. See [docs/architecture.md](docs/architecture.md) for a diagram and full detail.
 
 ## Features
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,10 +4,11 @@ Traffic Analytics is a web analytics proxy for Ghost. It receives page-hit event
 
 ## Run modes
 
-The same Docker image runs in two roles, selected by the `WORKER_MODE` environment variable in [`server.ts`](../server.ts):
+The same Docker image runs in three roles, selected by the `WORKER_MODE` environment variable in [`server.ts`](../server.ts):
 
 - **Ingest app** (`WORKER_MODE` unset — [`src/app.ts`](../src/app.ts)) — the Fastify HTTP server that receives `POST /api/v1/page_hit`.
 - **Worker app** (`WORKER_MODE=true` — [`src/worker-app.ts`](../src/worker-app.ts)) — a Pub/Sub consumer that enriches events and forwards them to Tinybird. It exposes only health endpoints (`/` and `/health`) for Cloud Run.
+- **Automation worker app** (`WORKER_MODE=automation` — [`src/automation-worker-app.ts`](../src/automation-worker-app.ts)) — a deployable scaffold with health endpoints and heartbeat logging. It does not subscribe to Pub/Sub yet.
 
 The ingest app has two request-handling strategies (see [`src/handlers/page-hit-handlers.ts`](../src/handlers/page-hit-handlers.ts)), chosen by whether `PUBSUB_TOPIC_PAGE_HITS_RAW` is set:
 
@@ -79,7 +80,7 @@ OpenTelemetry is initialised in [`src/utils/instrumentation.ts`](../src/utils/in
 
 - The trace exporter is Jaeger (OTLP HTTP) by default, or Google Cloud Trace when `OTEL_TRACE_EXPORTER=gcp` or `K_SERVICE` is set (Cloud Run sets `K_SERVICE` automatically).
 - OTLP endpoints default to the `jaeger` service (`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`).
-- The reported service name is `analytics-worker` in worker mode and `analytics-service` otherwise.
+- Outside Cloud Run, the reported service name follows the selected mode: `analytics-service`, `analytics-worker`, or `automation-worker`. In Cloud Run, `K_SERVICE` supplies the deployed service name.
 
 ## Related docs
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
 # Deployment
 
-Traffic Analytics deploys to **Google Cloud Run** in a single region (`europe-west4`, "netherlands"), across **staging** and **production** environments. Each environment runs two Cloud Run services: the ingest service and the worker.
+Traffic Analytics deploys to **Google Cloud Run** in a single region (`europe-west4`, "netherlands"), across **staging** and **production** environments. Each environment runs three Cloud Run services: the ingest service, the page-hit worker, and the automation worker.
 
 All deployment logic lives in [`.github/workflows/`](../.github/workflows) and a set of composite actions under [`.github/actions/`](../.github/actions).
 
@@ -12,8 +12,8 @@ flowchart TD
     Deploy --> Bump["Bump patch version<br/>commit + tag vX.Y.Z<br/>Slack notify"]
     Bump --> DH["Trigger docker-hub.yml<br/>(publish to Docker Hub)"]
     Bump --> Build["deploy-image-to-gcp.yml<br/>build + push to GCP Artifact Registry"]
-    Build --> Stg["deploy-environment.yml<br/>staging (analytics + worker)"]
-    Build --> Prd["deploy-environment.yml<br/>production (analytics + worker)"]
+    Build --> Stg["deploy-environment.yml<br/>staging (analytics + workers)"]
+    Build --> Prd["deploy-environment.yml<br/>production (analytics + workers)"]
     Stg --> HCS["run-healthchecks.yml<br/>staging"]
     Prd --> HCP["run-healthchecks.yml<br/>production"]
     Stg --> SlackS["Slack deploy summary"]
@@ -27,7 +27,7 @@ Triggered on every push to `main` (and via manual `workflow_dispatch`). Jobs:
 1. **Bump Version** — bumps the patch version with `npm version patch` (e.g. `1.2.3 → 1.2.4`), commits it as `vX.Y.Z [skip ci]`, pushes to `main`, and creates + pushes the `vX.Y.Z` git tag. Sends a Slack "new version released" notification. (The commit carries `[skip ci]`, so it does not re-trigger CI/deploy; a `GH_PAT` authorizes the push and tag to the protected branch, and the Docker Hub build is dispatched explicitly by the next job.)
 2. **Trigger Docker Hub Deploy** — dispatches [`docker-hub.yml`](../.github/workflows/docker-hub.yml) at the new `vX.Y.Z` tag.
 3. **Build** — calls [`deploy-image-to-gcp.yml`](../.github/workflows/deploy-image-to-gcp.yml) to build and push the image to GCP Artifact Registry.
-4. **Deploy Staging** and **Deploy Production** — both call [`deploy-environment.yml`](../.github/workflows/deploy-environment.yml) after the build, so the two environments deploy in parallel. Each deploys the `analytics` and `worker` services.
+4. **Deploy Staging** and **Deploy Production** — both call [`deploy-environment.yml`](../.github/workflows/deploy-environment.yml) after the build, so the two environments deploy in parallel. Each deploys the `analytics`, `worker`, and `automation-worker` services.
 5. **Healthcheck Staging / Production** — each runs [`run-healthchecks.yml`](../.github/workflows/run-healthchecks.yml), gated on its deploy job reporting `success`.
 
 ## Build & push image — [`deploy-image-to-gcp.yml`](../.github/workflows/deploy-image-to-gcp.yml)
@@ -44,10 +44,10 @@ A reusable (`workflow_call`) workflow that:
 Reusable workflow that takes `environment`, `image`, `region`, `region_name`, and a JSON `services` array. It runs a matrix over the services, deploying each to Cloud Run via the [`deploy-gcp-cloud-run`](../.github/actions/deploy-gcp-cloud-run) composite action. Cloud Run service names follow:
 
 ```text
-<stg|prd>-<region_name>-traffic-analytics[-worker]
+<stg|prd>-<region_name>-traffic-analytics[-worker|-automation-worker]
 ```
 
-(the `-worker` suffix is added for the `worker` service). A `notify` job then posts a Slack deployment summary.
+(the appropriate suffix is added for each worker service). The deployment explicitly sets `WORKER_MODE=true` for the page-hit worker and `WORKER_MODE=automation` for the automation worker. A `notify` job then posts a Slack deployment summary.
 
 ## Docker Hub release — [`docker-hub.yml`](../.github/workflows/docker-hub.yml)
 
@@ -64,7 +64,7 @@ The workflow requires the `HEALTHCHECK_WAF_BYPASS_TOKEN` GitHub Actions secret. 
 To test a branch on staging **without merging**, add the **`deploy-staging`** label to its PR. The workflow:
 
 1. Waits for the PR's CI run to finish if one is in progress.
-2. Builds and pushes the image, then deploys the `analytics` and `worker` services to staging.
+2. Builds and pushes the image, then deploys the `analytics`, `worker`, and `automation-worker` services to staging.
 3. Runs staging health checks.
 4. In a `finalize` step (always runs): comments on the PR with the result and the tree SHA, then **removes the `deploy-staging` label** so it can be re-applied to deploy again.
 

--- a/server.ts
+++ b/server.ts
@@ -2,14 +2,23 @@ import './src/utils/instrumentation';
 
 const port: number = parseInt(process.env.PORT || '3000', 10);
 const listenHost: string = process.env.LISTEN_HOST || '0.0.0.0';
-const isWorkerMode = process.env.WORKER_MODE === 'true';
+const workerMode = process.env.WORKER_MODE;
 
 // Load only the app this run mode needs. The production build currently inlines
-// both, but importing them dynamically lets it split them into separate chunks
+// all apps, but importing them dynamically lets it split them into separate chunks
 // once the Pub/Sub and Firestore clients are lazy too.
-const app = isWorkerMode
-    ? (await import('./src/worker-app')).default
-    : (await import('./src/app')).default;
+async function loadApp() {
+    switch (workerMode) {
+    case 'true':
+        return import('./src/worker-app');
+    case 'automation':
+        return import('./src/automation-worker-app');
+    default:
+        return import('./src/app');
+    }
+}
+
+const app = (await loadApp()).default;
 
 // Start the server if this file is run directly
 if (import.meta.main) {

--- a/src/automation-worker-app.ts
+++ b/src/automation-worker-app.ts
@@ -1,0 +1,25 @@
+import fastify from 'fastify';
+import loggingPlugin from './plugins/logging';
+import automationWorkerPlugin from './plugins/automation-worker-plugin';
+import {getLoggerConfig} from './utils/logger-config';
+import {fastifyOtelInstrumentation} from './utils/fastify-otel';
+
+const app = fastify({
+    logger: getLoggerConfig(),
+    disableRequestLogging: true,
+    trustProxy: process.env.TRUST_PROXY !== 'false'
+});
+
+app.register(fastifyOtelInstrumentation.plugin());
+app.register(loggingPlugin);
+app.register(automationWorkerPlugin);
+
+app.get('/', async () => {
+    return {status: 'automation-worker-healthy'};
+});
+
+app.get('/health', async () => {
+    return {status: 'automation-worker-healthy'};
+});
+
+export default app;

--- a/src/plugins/automation-worker-plugin.ts
+++ b/src/plugins/automation-worker-plugin.ts
@@ -1,0 +1,22 @@
+import type {FastifyInstance} from 'fastify';
+import fp from 'fastify-plugin';
+
+async function automationWorkerPlugin(fastify: FastifyInstance) {
+    let heartbeatInterval: NodeJS.Timeout | null = null;
+
+    fastify.addHook('onReady', async () => {
+        fastify.log.info({event: 'AutomationWorkerStarted'});
+
+        heartbeatInterval = setInterval(() => {
+            fastify.log.info({event: 'AutomationWorkerHeartbeat'});
+        }, 10000);
+    });
+
+    fastify.addHook('onClose', async () => {
+        if (heartbeatInterval) {
+            clearInterval(heartbeatInterval);
+        }
+    });
+}
+
+export default fp(automationWorkerPlugin);

--- a/src/utils/logger-config.ts
+++ b/src/utils/logger-config.ts
@@ -33,8 +33,14 @@ function getLogFormat(): LogFormat {
 }
 
 function getServiceContext(): {service: string; version?: string} {
-    const isWorkerMode = process.env.WORKER_MODE === 'true';
-    const service = process.env.K_SERVICE || (isWorkerMode ? 'analytics-worker' : 'analytics-service');
+    let localService = 'analytics-service';
+    if (process.env.WORKER_MODE === 'true') {
+        localService = 'analytics-worker';
+    } else if (process.env.WORKER_MODE === 'automation') {
+        localService = 'automation-worker';
+    }
+
+    const service = process.env.K_SERVICE || localService;
     const version = process.env.K_REVISION || process.env.npm_package_version;
 
     return version ? {service, version} : {service};

--- a/test/integration/server.test.ts
+++ b/test/integration/server.test.ts
@@ -124,6 +124,44 @@ describe('Server Conditional Loading', () => {
         });
     });
 
+    describe('Automation Worker App Loading (WORKER_MODE=automation)', () => {
+        beforeEach(async () => {
+            process.env.WORKER_MODE = 'automation';
+            vi.resetModules();
+
+            const serverModule = await import('../../server');
+            app = serverModule.default;
+            await app.ready();
+        });
+
+        it('should load the automation worker app', async () => {
+            const response = await request(app.server)
+                .get('/')
+                .expect(200);
+
+            expect(response.body).toEqual({
+                status: 'automation-worker-healthy'
+            });
+        });
+
+        it('should expose the automation worker health endpoint', async () => {
+            const response = await request(app.server)
+                .get('/health')
+                .expect(200);
+
+            expect(response.body).toEqual({
+                status: 'automation-worker-healthy'
+            });
+        });
+
+        it('should not expose ingest routes', async () => {
+            await request(app.server)
+                .post('/api/v1/page_hit')
+                .send({})
+                .expect(404);
+        });
+    });
+
     describe('Environment Variable Handling', () => {
         it('should handle WORKER_MODE with different casing', async () => {
             process.env.WORKER_MODE = 'TRUE';

--- a/test/unit/plugins/automation-worker-plugin.test.ts
+++ b/test/unit/plugins/automation-worker-plugin.test.ts
@@ -1,0 +1,41 @@
+import fastify, {type FastifyInstance} from 'fastify';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import automationWorkerPlugin from '../../../src/plugins/automation-worker-plugin';
+
+describe('automationWorkerPlugin', () => {
+    let app: FastifyInstance;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        app = fastify();
+    });
+
+    afterEach(async () => {
+        await app.close();
+        vi.useRealTimers();
+    });
+
+    it('logs startup and heartbeat events', async () => {
+        const logInfo = vi.spyOn(app.log, 'info');
+
+        app.register(automationWorkerPlugin);
+        await app.ready();
+
+        expect(logInfo).toHaveBeenCalledWith({event: 'AutomationWorkerStarted'});
+
+        await vi.advanceTimersByTimeAsync(10000);
+
+        expect(logInfo).toHaveBeenCalledWith({event: 'AutomationWorkerHeartbeat'});
+    });
+
+    it('stops the heartbeat when the app closes', async () => {
+        app.register(automationWorkerPlugin);
+        await app.ready();
+
+        expect(vi.getTimerCount()).toBe(1);
+
+        await app.close();
+
+        expect(vi.getTimerCount()).toBe(0);
+    });
+});

--- a/test/unit/utils/logger.test.ts
+++ b/test/unit/utils/logger.test.ts
@@ -221,6 +221,17 @@ describe('Logger Config', () => {
                 versionAssertion: 'exact'
             },
             {
+                name: 'should include automation worker service context when WORKER_MODE is automation and K_SERVICE is missing',
+                event: 'service-context-automation-worker',
+                env: {
+                    K_SERVICE: '',
+                    WORKER_MODE: 'automation'
+                },
+                expectedService: 'automation-worker',
+                expectedVersion: undefined,
+                versionAssertion: 'ignore'
+            },
+            {
                 name: 'should not use worker service context when WORKER_MODE is false',
                 event: 'service-context-worker-mode-false',
                 env: {


### PR DESCRIPTION
## Summary

- add a standalone automation worker mode with health endpoints and heartbeat logging
- deploy the automation worker as a third Cloud Run service in staging and production
- add worker-mode, logging, and lifecycle coverage without adding Pub/Sub processing

## Verification

- pnpm build
- pnpm lint
- pnpm test:unit
- server-mode integration tests and production boot smoke test