### PR TITLE
Fixed Tinybird sync worker setup for local Ghost development

### DIFF
--- a/compose.ghost.yml
+++ b/compose.ghost.yml
@@ -15,6 +15,12 @@ services:
     networks:
       - ghost
 
+  tinybird-sync:
+    volumes:
+      - ghost-shared-config:/mnt/shared-config:ro
+    networks:
+      - ghost
+
 volumes:
   ghost-shared-config:
     external: true

--- a/compose.override.yml
+++ b/compose.override.yml
@@ -18,6 +18,11 @@ services:
       - .:/app
       - node_modules_volume:/app/node_modules
 
+  tinybird-sync:
+    volumes:
+      - .:/app
+      - node_modules_volume:/app/node_modules
+
   test:
     volumes:
       - .:/app

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "pnpm dev:batch",
     "dev:proxy": "docker compose up -d --wait && docker compose up analytics-service-proxy",
     "dev:batch": "docker compose up -d --wait && docker compose up analytics-service worker tinybird-sync",
-    "dev:ghost": "docker compose -f compose.yml -f compose.ghost.yml -f compose.override.yml up -d --wait && docker compose -f compose.yml -f compose.ghost.yml -f compose.override.yml up --force-recreate analytics-service worker",
+    "dev:ghost": "docker compose -f compose.yml -f compose.ghost.yml -f compose.override.yml up -d --wait && docker compose -f compose.yml -f compose.ghost.yml -f compose.override.yml up --force-recreate analytics-service worker tinybird-sync",
     "start": "node --enable-source-maps dist/server.js",
     "start:worker": "WORKER_MODE=true node --enable-source-maps dist/server.js",
     "start:tinybird-sync-worker": "WORKER_MODE=tinybird-sync node --enable-source-maps dist/server.js",


### PR DESCRIPTION
no ref

The Ghost development command must start the sync worker alongside ingest and page-hit processing. Mount the current source and shared Tinybird credentials, and join the Ghost network so queued automation events reach the local Tinybird instance.