### PR TITLE
Removed unused option from event publisher

### DIFF
--- a/src/services/events/publisher.ts
+++ b/src/services/events/publisher.ts
@@ -38,8 +38,7 @@ class EventPublisher {
     async publishEvent({topic, payload, logger}: PublishEventOptions): Promise<string> {
         try {
             const message = {
-                data: Buffer.from(JSON.stringify(payload)),
-                timestamp: new Date().toISOString()
+                data: Buffer.from(JSON.stringify(payload))
             };
 
             const messageId = await this.getTopic(topic).publishMessage(message);


### PR DESCRIPTION
no ref

`Topic.prototype.publishMessage()` doesn't use this option, so it's useless. We don't use it either. Let's remove it.
