### PR TITLE
Updated Fastify request logging configuration

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,5 @@
 // Main module file
-import fastify from 'fastify';
+import fastify, {LogController} from 'fastify';
 import {serializerCompiler, validatorCompiler, type ZodTypeProvider} from './schemas';
 import loggingPlugin from './plugins/logging';
 import timestampPlugin from './plugins/timestamp';
@@ -14,7 +14,7 @@ import {fastifyOtelInstrumentation} from './utils/fastify-otel';
 
 const app = fastify({
     logger: getLoggerConfig(),
-    disableRequestLogging: true,
+    logController: new LogController({disableRequestLogging: true}),
     trustProxy: process.env.TRUST_PROXY !== 'false'
 }).withTypeProvider<ZodTypeProvider>();
 

--- a/src/tinybird-sync-worker-app.ts
+++ b/src/tinybird-sync-worker-app.ts
@@ -1,4 +1,4 @@
-import fastify from 'fastify';
+import fastify, {LogController} from 'fastify';
 import loggingPlugin from './plugins/logging';
 import tinybirdSyncWorkerPlugin from './plugins/tinybird-sync-worker-plugin';
 import {getLoggerConfig} from './utils/logger-config';
@@ -6,7 +6,7 @@ import {fastifyOtelInstrumentation} from './utils/fastify-otel';
 
 const app = fastify({
     logger: getLoggerConfig(),
-    disableRequestLogging: true,
+    logController: new LogController({disableRequestLogging: true}),
     trustProxy: process.env.TRUST_PROXY !== 'false'
 });
 

--- a/src/worker-app.ts
+++ b/src/worker-app.ts
@@ -1,5 +1,5 @@
 // Worker module file
-import fastify from 'fastify';
+import fastify, {LogController} from 'fastify';
 import loggingPlugin from './plugins/logging';
 import workerPlugin from './plugins/worker-plugin';
 import {getLoggerConfig} from './utils/logger-config';
@@ -8,7 +8,7 @@ import {fastifyOtelInstrumentation} from './utils/fastify-otel';
 
 const app = fastify({
     logger: getLoggerConfig(),
-    disableRequestLogging: true,
+    logController: new LogController({disableRequestLogging: true}),
     trustProxy: process.env.TRUST_PROXY !== 'false'
 });
 


### PR DESCRIPTION
no refs

## Summary

Replaced the deprecated Fastify `disableRequestLogging` option with `LogController` configuration across the ingest app and worker entrypoints. This preserves disabled request logging while keeping the service compatible with the current Fastify API.

--- 
Aside: the rationale for disabling request logging in the first place is that we have our own custom request logs with some more detailed information, so disabling the default request logs saves us one redundant log per request.